### PR TITLE
Document GitHub marketplace install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,27 @@ This repository is a Claude Code marketplace plugin that shells out to the real 
 - Grok Build CLI (`grok`) on `PATH`, or set `GROK_BINARY`
 - A logged-in Grok CLI session (`grok models` succeeds)
 
-## Local install
+## Install
+
+Add the marketplace in Claude Code:
+
+```bash
+/plugin marketplace add xai-org/grok-build-plugin-cc
+```
+
+Install the plugin:
+
+```bash
+/plugin install grok-build@xai-grok-build
+```
+
+Reload plugins:
+
+```bash
+/reload-plugins
+```
+
+### Local install (from a clone)
 
 From this repository root (path must be absolute):
 


### PR DESCRIPTION
## Summary
- Add an `## Install` section documenting `/plugin marketplace add xai-org/grok-build-plugin-cc` + `/plugin install grok-build@xai-grok-build` + `/reload-plugins`, matching the pattern in [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc#install)
- Keep the existing local-clone flow under a new `### Local install (from a clone)` subsection

## Test plan
- [x] Verified `/plugin marketplace add xai-org/grok-build-plugin-cc` and `/plugin install grok-build@xai-grok-build` work end-to-end (marketplace name `xai-grok-build`, plugin name `grok-build`, confirmed against `.claude-plugin/marketplace.json`)