### PR TITLE
fix: untracked-symlink review context can leak out-of-repo file contents

### DIFF
--- a/plugins/grok-build/scripts/lib/git.mjs
+++ b/plugins/grok-build/scripts/lib/git.mjs
@@ -195,6 +195,31 @@ function formatSection(title, body) {
 
 function formatUntrackedFile(cwd, relativePath) {
   const absolutePath = path.join(cwd, relativePath);
+
+  let lstat;
+  try {
+    lstat = fs.lstatSync(absolutePath);
+  } catch {
+    return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+  }
+  if (lstat.isSymbolicLink()) {
+    // review/critique are documented as read-only and repo-scoped: an untracked
+    // symlink whose target lies outside the repo must not have that target's
+    // contents read into the prompt (e.g. `leak.txt -> ~/.aws/credentials`).
+    // Mirrors the realpath + containment check in claude-session-transfer.mjs.
+    let real;
+    try {
+      real = fs.realpathSync(absolutePath);
+    } catch {
+      return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+    }
+    const repoRoot = fs.realpathSync(cwd);
+    const rel = path.relative(repoRoot, real);
+    if (rel === "" || rel === ".." || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
+      return `### ${relativePath}\n(skipped: symlink escapes repository)`;
+    }
+  }
+
   let stat;
   try {
     stat = fs.statSync(absolutePath);

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -54,3 +54,50 @@ test("resolveReviewTarget honors explicit base overrides", () => {
   assert.equal(target.baseRef, "main");
   assert.equal(target.explicit, true);
 });
+
+test("collectReviewContext does not inline the target of an untracked symlink that escapes the repo", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  const secretDir = makeTempDir("grok-build-plugin-secret-");
+  const secretPath = path.join(secretDir, "credentials");
+  fs.writeFileSync(secretPath, "AKIA_SUPER_SECRET_VALUE\n");
+  fs.symlinkSync(secretPath, path.join(cwd, "leak.txt"));
+
+  const context = collectReviewContext(cwd, { mode: "working-tree" }, { includeDiff: true });
+
+  assert.doesNotMatch(context.content, /AKIA_SUPER_SECRET_VALUE/);
+  assert.match(context.content, /leak\.txt[\s\S]*skipped: symlink escapes repository/);
+});
+
+test("collectReviewContext still inlines an untracked symlink that stays inside the repo", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  fs.writeFileSync(path.join(cwd, "real.txt"), "in-repo content\n");
+  fs.symlinkSync(path.join(cwd, "real.txt"), path.join(cwd, "link.txt"));
+
+  const context = collectReviewContext(cwd, { mode: "working-tree" }, { includeDiff: true });
+
+  assert.match(context.content, /in-repo content/);
+});
+
+test("collectReviewContext skips an untracked symlink whose target does not exist", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  fs.symlinkSync(path.join(cwd, "does-not-exist"), path.join(cwd, "broken.txt"));
+
+  const context = collectReviewContext(cwd, { mode: "working-tree" }, { includeDiff: true });
+
+  assert.match(context.content, /broken\.txt[\s\S]*skipped: broken symlink or unreadable file/);
+});


### PR DESCRIPTION
Fixes #4.

## Summary

`formatUntrackedFile()` in `plugins/grok-build/scripts/lib/git.mjs` built review/critique context for untracked files using `fs.statSync` + `fs.readFileSync`, both of which follow symlinks. An untracked symlink inside the repo whose target lies outside it (e.g. `leak.txt -> ~/.aws/credentials`) had its **target's** contents read and inlined into the prompt sent to the `grok` CLI — and thus to xAI — as long as the target was ≤24KB and looked like text.

`review`/`critique` are documented as read-only and repo-scoped, so a user can reasonably assume nothing outside the repository leaves the machine. Following symlinks breaks that assumption.

Tracked changes aren't affected: `git diff --binary` encodes a symlink as its link-target *path* (the blob is the path string), so this was specific to the untracked path via `readFileSync`.

## Fix

`lstat` the entry first. If it's a symlink, `realpath` both it and the repo root and containment-check before reading — this mirrors the existing, already-correct pattern in `claude-session-transfer.mjs` for the same class of symlink-escape guard, rather than inventing a new approach:

```js
if (lstat.isSymbolicLink()) {
  const real = fs.realpathSync(absolutePath);
  const repoRoot = fs.realpathSync(cwd);
  const rel = path.relative(repoRoot, real);
  if (rel === "" || rel === ".." || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
    return `### ${relativePath}\n(skipped: symlink escapes repository)`;
  }
}
```

A symlink that escapes the repo is now skipped with a note instead of read. An untracked symlink whose target stays *inside* the repo is still inlined as before (no behavior change for the safe case), and non-symlink untracked files are unaffected.

## Tests

Added 3 tests to `tests/git.test.mjs`, using real temp git repos + real symlinks (matching this file's existing test style, no `fs` mocking):
- an escaping symlink no longer inlines its target's contents
- an in-repo symlink still gets inlined
- a broken symlink still shows the existing "unreadable file" message

Confirmed the escaping-symlink test **fails** against the pre-fix code (the secret string `AKIA_SUPER_SECRET_VALUE` appears in `context.content`) by isolating just `git.mjs` via `git stash` and rerunning — confirms the vulnerability reproduces exactly as described in #4 before the fix, and is closed by it.

```
node --test tests/*.test.mjs
# 61 passed (58 baseline + 3 new), 0 failed, 0 regressions
```

No linter is configured in this repo (checked for `.eslintrc*`/`eslint.config*`/`.prettierrc*` — none found), so nothing further to run there.