### PR TITLE
fix: stop signals a job's pre-claim pids before confirming it won the cancel claim

### DIFF
--- a/plugins/grok-build/scripts/grok-bridge.mjs
+++ b/plugins/grok-build/scripts/grok-bridge.mjs
@@ -986,15 +986,19 @@ async function handleCancel(argv) {
     logFile: existing.logFile ?? job.logFile ?? null
   });
 
-  const killResult = terminateJobProcessTrees(preClaimRecord);
-
   if (!claim.claimed && claim.status && claim.status !== "cancelled") {
+    // The job already reached a terminal state before this claim landed, so
+    // the kill must not run at all: preClaimRecord's pids no longer belong to
+    // this job, and signaling them risks hitting an unrelated process that
+    // has since reused the pid. This is the claim-before-kill guarantee the
+    // README describes -- the kill is gated on winning the claim, not just
+    // ordered after attempting it.
     const payload = {
       jobId: job.id,
       status: claim.status,
       title: claim.job?.title ?? job.title,
-      killAttempted: killResult.attempted,
-      killDelivered: killResult.delivered,
+      killAttempted: false,
+      killDelivered: false,
       alreadyTerminal: true,
       claimOrder: "claim-before-kill",
       killTargets
@@ -1006,6 +1010,8 @@ async function handleCancel(argv) {
     );
     return;
   }
+
+  const killResult = terminateJobProcessTrees(preClaimRecord);
 
   appendLogLine(
     existing.logFile ?? job.logFile,
@@ -1099,4 +1105,4 @@ if (isMain) {
   });
 }
 
-export { main, readStoredJobWithRetry };
+export { handleCancel, main, readStoredJobWithRetry };

--- a/tests/job-terminal.test.mjs
+++ b/tests/job-terminal.test.mjs
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -12,6 +13,25 @@ import {
   writeJobFile
 } from "../plugins/grok-build/scripts/lib/state.mjs";
 import { resolveJobKillTargets } from "../plugins/grok-build/scripts/lib/tracked-jobs.mjs";
+import { handleCancel } from "../plugins/grok-build/scripts/grok-bridge.mjs";
+
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(predicate, { timeoutMs = 2000, intervalMs = 20 } = {}) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  return predicate();
+}
 
 function withPluginData(fn) {
   const previous = process.env.CLAUDE_PLUGIN_DATA;
@@ -194,6 +214,132 @@ test("stop claim-before-kill ordering: claim cancelled then kill targets from pr
     assert.equal(late.reason, "cancelled-wins");
   });
 });
+
+// Regression tests for #3: `stop` must not signal a job's pre-claim pids
+// unless it actually won the cancel claim.
+//
+// The bug report's exact TOCTOU window -- the target job finishing on its
+// own between handleCancel's initial (unlocked) resolveCancelableJob read
+// and its claimJobTerminal call -- happens across two real OS processes and
+// can't be landed deterministically from a single-process test.
+//
+// listJobs() (which resolveCancelableJob uses to find "active" jobs) reads
+// only the aggregate state index, while claimJobTerminal() prefers the
+// per-job file over the index (readJobFileIfPresent(...) ?? indexJob). A job
+// whose file has already been updated to a terminal status but whose index
+// entry hasn't caught up yet is exactly the state two racing writers would
+// leave behind mid-update -- and it's fully deterministic to construct
+// directly, without timing. These call the real, now-exported handleCancel()
+// against a real child process, so the actual kill call (or its absence) is
+// what's observed, not a re-implementation of its branching.
+test("stop does not signal a job's process when the cancel claim is lost", async () => {
+  await withPluginDataAsync(async () => {
+    const workspace = makeTempDir();
+    const jobId = "job-claim-lost-no-kill";
+    const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
+      stdio: "ignore",
+      detached: true
+    });
+    child.unref();
+    try {
+      await waitFor(() => isAlive(child.pid));
+
+      const running = {
+        id: jobId,
+        status: "running",
+        phase: "running",
+        title: "Claim lost",
+        bridgePid: child.pid,
+        agentPid: child.pid,
+        pid: child.pid
+      };
+      // Index says "running" (what resolveCancelableJob sees)...
+      upsertJob(workspace, running);
+      // ...but the file already moved to "completed" (what claimJobTerminal
+      // prefers), simulating the job finishing just ahead of `stop`.
+      writeJobFile(workspace, jobId, { ...running, status: "completed", phase: "completed" });
+
+      await handleCancel([jobId, "--cwd", workspace, "--json"]);
+
+      const stored = readJobFile(resolveJobFile(workspace, jobId));
+      assert.equal(stored.status, "completed");
+      // terminateProcessTree has an internal ~200ms SIGTERM grace period
+      // before it would escalate to SIGKILL, so an immediate isAlive() check
+      // would pass whether or not a kill was even attempted. Wait past that
+      // window to actually observe the outcome.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      assert.equal(isAlive(child.pid), true);
+    } finally {
+      try {
+        process.kill(-child.pid, "SIGKILL");
+      } catch {
+        try {
+          process.kill(child.pid, "SIGKILL");
+        } catch {
+          // already dead
+        }
+      }
+    }
+  });
+});
+
+test("stop does signal a job's process when the cancel claim is won", async () => {
+  await withPluginDataAsync(async () => {
+    const workspace = makeTempDir();
+    const jobId = "job-claim-won-kill";
+    const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
+      stdio: "ignore",
+      detached: true
+    });
+    child.unref();
+    try {
+      await waitFor(() => isAlive(child.pid));
+
+      const running = {
+        id: jobId,
+        status: "running",
+        phase: "running",
+        title: "Claim won",
+        bridgePid: child.pid,
+        agentPid: child.pid,
+        pid: child.pid
+      };
+      writeJobFile(workspace, jobId, running);
+      upsertJob(workspace, running);
+
+      await handleCancel([jobId, "--cwd", workspace, "--json"]);
+
+      const stored = readJobFile(resolveJobFile(workspace, jobId));
+      assert.equal(stored.status, "cancelled");
+      const died = await waitFor(() => !isAlive(child.pid));
+      assert.equal(died, true);
+    } finally {
+      try {
+        process.kill(-child.pid, "SIGKILL");
+      } catch {
+        try {
+          process.kill(child.pid, "SIGKILL");
+        } catch {
+          // already dead
+        }
+      }
+    }
+  });
+});
+
+function withPluginDataAsync(fn) {
+  const previous = process.env.CLAUDE_PLUGIN_DATA;
+  process.env.CLAUDE_PLUGIN_DATA = makeTempDir();
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      if (previous == null) {
+        delete process.env.CLAUDE_PLUGIN_DATA;
+      } else {
+        process.env.CLAUDE_PLUGIN_DATA = previous;
+      }
+    });
+}
 
 test("patchJobIfActive does not resurrect terminal jobs when patching worker pid", () => {
   withPluginData(() => {


### PR DESCRIPTION
Fixes #3.

## Summary

In `handleCancel()` (`plugins/grok-build/scripts/grok-bridge.mjs`, backing `/grok-build:stop`) the order was:

```js
const claim = claimJobTerminal(workspaceRoot, job.id, "cancelled", { ... });   // (1) claim
const killResult = terminateJobProcessTrees(preClaimRecord);                    // (2) kill (pre-claim pids)
if (!claim.claimed && claim.status && claim.status !== "cancelled") {           // (3) claim-lost guard
  return;
}
```

The claim (1) does run before the kill (2) — but the guard that inspects the claim *result* (3) runs after the kill. So when a job already reached a terminal state before `stop`'s claim landed (`claim.claimed === false`), step (2) still delivers signals to `preClaimRecord`'s `agentPid`/`bridgePid`, which no longer belong to this job. If the OS has recycled one of those pids, `stop` signals an unrelated process. This also contradicts the README's stated "claim-before-kill" guarantee, which implies the kill is gated on winning the claim, not just ordered after attempting it.

## Fix

Move the claim-lost early return **above** `terminateJobProcessTrees`, so the kill only runs when `stop` actually owns the cancellation (or the job was already `cancelled`). The early-return payload's `killAttempted`/`killDelivered` fields are now hardcoded `false`, since no kill happens on that path anymore.

Exported `handleCancel` so it's directly testable.

## Tests

Added 2 tests to `tests/job-terminal.test.mjs`:
- `stop does not signal a job's process when the cancel claim is lost`
- `stop does signal a job's process when the cancel claim is won` — a positive control, proving the test setup can actually detect a kill when one should happen, so the negative test's assertion is meaningful rather than trivially passing.

The claim-lost precondition is constructed **deterministically, with no timing dependency**: `listJobs()` (what `resolveCancelableJob` uses to find "active" jobs) reads only the aggregate state index, while `claimJobTerminal()` prefers the per-job file over the index (`readJobFileIfPresent(...) ?? indexJob`). Writing the index as `"running"` and the job file as `"completed"` reproduces exactly the state two racing writers would leave behind mid-update, without needing real inter-process concurrency or sleeps — the original bug's TOCTOU window (a real concurrent process finishing the job) isn't otherwise reproducible deterministically through the public CLI surface, since `resolveCancelableJob` only returns jobs whose *index* entry is still active in the first place.

## Verification

Confirmed the negative test **fails** against the pre-fix ordering — tested by reverting just the reordering while keeping the `handleCancel` export, and the spawned child process actually gets killed (`killAttempted: true, killDelivered: true`), a live reproduction of the bug rather than an assertion on a return value alone.

One subtlety worth calling out: `terminateProcessTree` has an internal ~200ms SIGTERM grace period, so an immediate post-`handleCancel` `isAlive()` check would pass regardless of whether a kill was even attempted. The negative test waits past that window before asserting.

```
node --test tests/*.test.mjs
# 60 passed (58 baseline + 2 new), 0 failed, 0 regressions
```

No linter is configured in this repo (checked for `.eslintrc*`/`eslint.config*`/`.prettierrc*` — none found).