### PR TITLE
fix: headless read-only runs can't auto-approve within their own sandbox

### DIFF
--- a/plugins/grok-build/scripts/grok-bridge.mjs
+++ b/plugins/grok-build/scripts/grok-bridge.mjs
@@ -328,7 +328,10 @@ async function executeReviewRun(request) {
   const result = await runHeadlessAgent(context.repoRoot, {
     prompt,
     agent: "explore",
-    permissionMode: "plan",
+    // Headless runs have no user to click Approve, so "plan" mode with no
+    // approver can hang or fail on any tool call. `sandbox: "read-only"` is
+    // the actual safety boundary here, so auto-approving within it is safe.
+    alwaysApprove: true,
     sandbox: "read-only",
     model: request.model,
     effort: request.effort,
@@ -444,8 +447,11 @@ async function executeTaskRun(request) {
     resumeSessionId,
     model: request.model,
     effort: request.effort,
-    alwaysApprove: write,
-    permissionMode: write ? undefined : "plan",
+    // Headless runs have no user to click Approve, so a read-only run using
+    // "plan" mode with no approver can hang or fail on any tool call.
+    // `sandbox: "read-only"` is the actual safety boundary, so auto-approve
+    // is safe in both the write and read-only cases here.
+    alwaysApprove: true,
     sandbox: write ? undefined : "read-only",
     outputFormat: "plain",
     onProgress: request.onProgress

--- a/tests/grok-bridge-permissions.test.mjs
+++ b/tests/grok-bridge-permissions.test.mjs
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+import { buildEnv, installFakeGrok } from "./fake-grok-fixture.mjs";
+import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PLUGIN_ROOT = path.join(ROOT, "plugins", "grok-build");
+const SCRIPT = path.join(PLUGIN_ROOT, "scripts", "grok-bridge.mjs");
+
+function pluginDataEnv(pluginDataDir, binDir, extra = {}) {
+  return buildEnv(binDir, {
+    CLAUDE_PLUGIN_DATA: pluginDataDir,
+    ...extra
+  });
+}
+
+function lastFakeGrokArgv(logPath) {
+  const lines = fs
+    .readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  const printRun = [...lines].reverse().find((entry) => entry.argv?.includes("-p"));
+  assert.ok(printRun, "expected a headless grok -p invocation");
+  return printRun.argv;
+}
+
+function setupRepo() {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const pluginDataDir = makeTempDir();
+  const fakeGrokLog = path.join(pluginDataDir, "fake-grok.log");
+  installFakeGrok(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "src.js"), "export const value = 1;\n");
+  run("git", ["add", "src.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "src.js"), "export const value = 2;\n");
+  return { repo, binDir, pluginDataDir, fakeGrokLog };
+}
+
+// Regression tests for https://github.com/xai-org/grok-build-plugin-cc/issues/5
+//
+// Headless runs (review, and `run` without --write) have no user who can
+// click Approve, so passing --permission-mode plan with no auto-approve
+// left every tool call with nobody able to approve it. The sandbox
+// (--sandbox read-only) is the real safety boundary for these paths, so
+// auto-approve is safe to combine with it.
+
+test("review passes --always-approve alongside --sandbox read-only", () => {
+  const { repo, binDir, pluginDataDir, fakeGrokLog } = setupRepo();
+
+  const result = run("node", [SCRIPT, "review"], {
+    cwd: repo,
+    env: pluginDataEnv(pluginDataDir, binDir, { FAKE_GROK_LOG: fakeGrokLog })
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const argv = lastFakeGrokArgv(fakeGrokLog);
+  assert.ok(argv.includes("--always-approve"), argv.join(" "));
+  assert.ok(argv.includes("--sandbox"), argv.join(" "));
+  assert.equal(argv[argv.indexOf("--sandbox") + 1], "read-only");
+});
+
+test("run without --write passes --always-approve alongside --sandbox read-only", () => {
+  const { repo, binDir, pluginDataDir, fakeGrokLog } = setupRepo();
+
+  const result = run("node", [SCRIPT, "run", "check auth preflight"], {
+    cwd: repo,
+    env: pluginDataEnv(pluginDataDir, binDir, { FAKE_GROK_LOG: fakeGrokLog })
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const argv = lastFakeGrokArgv(fakeGrokLog);
+  assert.ok(argv.includes("--always-approve"), argv.join(" "));
+  assert.ok(argv.includes("--sandbox"), argv.join(" "));
+  assert.equal(argv[argv.indexOf("--sandbox") + 1], "read-only");
+});
+
+test("run with --write passes --always-approve without a sandbox flag", () => {
+  const { repo, binDir, pluginDataDir, fakeGrokLog } = setupRepo();
+
+  const result = run("node", [SCRIPT, "run", "--write", "make the change"], {
+    cwd: repo,
+    env: pluginDataEnv(pluginDataDir, binDir, { FAKE_GROK_LOG: fakeGrokLog })
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const argv = lastFakeGrokArgv(fakeGrokLog);
+  assert.ok(argv.includes("--always-approve"), argv.join(" "));
+  assert.ok(!argv.includes("--sandbox"), argv.join(" "));
+});


### PR DESCRIPTION
## Summary

Fixes #5.

`executeReviewRun` and the read-only branch of `executeTaskRun` in `grok-bridge.mjs` passed `--permission-mode plan` with no `--always-approve`. Both are headless invocations (`/grok-build:review` and `/grok-build:delegate` without `--write`) — there is no user who can click Approve — so any tool call needing approval had nobody able to grant it, exactly as described in #5.

`--sandbox read-only` is the actual safety boundary for these paths, so combining it with `--always-approve` is safe, and matches the pattern the `--write` branch already uses one line below (`alwaysApprove: write` with no sandbox when `write` is true).

## Changes

- `executeReviewRun`: `permissionMode: "plan"` → `alwaysApprove: true` (keeps `sandbox: "read-only"`)
- `executeTaskRun`: `alwaysApprove: write` → `alwaysApprove: true` unconditionally; dropped the now-redundant `permissionMode` branch (kept `sandbox: write ? undefined : "read-only"` unchanged)

## Test plan

- Added `tests/grok-bridge-permissions.test.mjs`, following the existing `FAKE_GROK_LOG` fixture pattern to assert on the actual argv the fake `grok` binary receives:
  - `review` passes `--always-approve` alongside `--sandbox read-only`
  - `run` without `--write` passes `--always-approve` alongside `--sandbox read-only`
  - `run --write` passes `--always-approve` with no `--sandbox` flag (unchanged behavior)
- Confirmed the first two new tests fail against the pre-fix code (`git stash`) and pass after the fix.
- Full suite: `npm test` → 61 passed, 0 failed, 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)