### PR TITLE
fix: disable shell for git commands on Windows (EXSECRE-1190)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Grok Build ↔ Claude Code bridge plugins for review, critique, and delegation.",
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
   "plugins": [
     {
       "name": "grok-build",
       "description": "Grok Build ↔ Claude Code bridge for review, critique, and delegation.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "xAI"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xai/grok-build-plugin-cc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "description": "Grok Build ↔ Claude Code bridge for review, critique, and delegation.",

--- a/plugins/grok-build/.claude-plugin/plugin.json
+++ b/plugins/grok-build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-build",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Grok Build ↔ Claude Code bridge for review, critique, and delegation.",
   "author": {
     "name": "xAI"

--- a/plugins/grok-build/scripts/lib/git.mjs
+++ b/plugins/grok-build/scripts/lib/git.mjs
@@ -8,12 +8,17 @@ const MAX_UNTRACKED_BYTES = 24 * 1024;
 const DEFAULT_INLINE_DIFF_MAX_FILES = 2;
 const DEFAULT_INLINE_DIFF_MAX_BYTES = 256 * 1024;
 
+// Git is directly executable on Windows. Repository-derived arguments
+// (branch names, refs) must never pass through a shell — shell:true on
+// Windows concatenates argv without escaping (Node DEP0190), so a ref
+// such as `main&probe.cmd` can run a tracked batch file. shell:false is
+// applied last so callers cannot re-enable the shell.
 function git(cwd, args, options = {}) {
-  return runCommand("git", args, { cwd, ...options });
+  return runCommand("git", args, { cwd, ...options, shell: false });
 }
 
 function gitChecked(cwd, args, options = {}) {
-  return runCommandChecked("git", args, { cwd, ...options });
+  return runCommandChecked("git", args, { cwd, ...options, shell: false });
 }
 
 function listUniqueFiles(...groups) {

--- a/plugins/grok-build/scripts/lib/process.mjs
+++ b/plugins/grok-build/scripts/lib/process.mjs
@@ -12,6 +12,11 @@ function sleepMs(ms) {
 
 export function runCommand(command, args = [], options = {}) {
   const spawnSyncImpl = options.spawnSyncImpl ?? spawnSync;
+  // Never enable a shell when passing a discrete args array. On Windows,
+  // shell:true concatenates argv without escaping (Node DEP0190), so a
+  // repository-controlled ref such as `main&probe.cmd` becomes a second
+  // host command. Fixed binaries (git, grok, taskkill) must receive args
+  // as an argv array on every platform.
   const result = spawnSyncImpl(command, args, {
     cwd: options.cwd,
     env: options.env,
@@ -19,7 +24,7 @@ export function runCommand(command, args = [], options = {}) {
     input: options.input,
     maxBuffer: options.maxBuffer,
     stdio: options.stdio ?? "pipe",
-    shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+    shell: false,
     windowsHide: true
   });
 

--- a/plugins/grok-build/scripts/lib/process.mjs
+++ b/plugins/grok-build/scripts/lib/process.mjs
@@ -12,11 +12,9 @@ function sleepMs(ms) {
 
 export function runCommand(command, args = [], options = {}) {
   const spawnSyncImpl = options.spawnSyncImpl ?? spawnSync;
-  // Never enable a shell when passing a discrete args array. On Windows,
-  // shell:true concatenates argv without escaping (Node DEP0190), so a
-  // repository-controlled ref such as `main&probe.cmd` becomes a second
-  // host command. Fixed binaries (git, grok, taskkill) must receive args
-  // as an argv array on every platform.
+  // Windows may need a shell to resolve .cmd shims (e.g. tool CLIs). Callers
+  // that pass repository-derived argv (especially git refs) must force
+  // shell: false — see git.mjs — so shell metacharacters are not expanded.
   const result = spawnSyncImpl(command, args, {
     cwd: options.cwd,
     env: options.env,
@@ -24,7 +22,7 @@ export function runCommand(command, args = [], options = {}) {
     input: options.input,
     maxBuffer: options.maxBuffer,
     stdio: options.stdio ?? "pipe",
-    shell: false,
+    shell: options.shell ?? (process.platform === "win32" ? (process.env.SHELL || true) : false),
     windowsHide: true
   });
 

--- a/tests/bump-version.test.mjs
+++ b/tests/bump-version.test.mjs
@@ -74,7 +74,7 @@ test("bump-version check mode reports stale metadata", () => {
   assert.match(result.stderr, /\.claude-plugin\/marketplace\.json metadata\.version/);
 });
 
-test("repo manifests are in sync at 0.2.0", () => {
-  const result = run("node", [SCRIPT, "--check", "0.2.0"], { cwd: ROOT });
+test("repo manifests are in sync at 0.2.1", () => {
+  const result = run("node", [SCRIPT, "--check", "0.2.1"], { cwd: ROOT });
   assert.equal(result.status, 0, result.stderr);
 });

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -38,6 +38,36 @@ test("resolveReviewTarget falls back to branch diff when repo is clean", () => {
   assert.match(context.content, /Branch Diff/);
 });
 
+test("default branch names with special characters are passed to git literally", () => {
+  const cwd = makeTempDir();
+  const branchName = "main&branch-helper&x";
+  const helperOutputPath = path.join(cwd, "branch-helper-output");
+  initGitRepo(cwd);
+  // Windows-style batch helper; if shell expansion occurs, running it writes this marker.
+  fs.writeFileSync(path.join(cwd, "branch-helper.cmd"), "@echo branch-helper>branch-helper-output\r\n");
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('base');\n");
+  run("git", ["add", "app.js", "branch-helper.cmd"], { cwd });
+  run("git", ["commit", "-m", "base"], { cwd });
+  run("git", ["branch", "-m", branchName], { cwd, shell: false });
+  run("git", ["update-ref", `refs/remotes/origin/${branchName}`, branchName], { cwd, shell: false });
+  run("git", ["symbolic-ref", "refs/remotes/origin/HEAD", `refs/remotes/origin/${branchName}`], {
+    cwd,
+    shell: false
+  });
+  run("git", ["checkout", "-b", "feature/test"], { cwd });
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('feature');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "feature"], { cwd });
+
+  const target = resolveReviewTarget(cwd, {});
+  const context = collectReviewContext(cwd, target);
+
+  assert.equal(target.mode, "branch");
+  assert.equal(target.baseRef, branchName);
+  assert.match(context.content, /Branch Diff/);
+  assert.equal(fs.existsSync(helperOutputPath), false);
+});
+
 test("resolveReviewTarget honors explicit base overrides", () => {
   const cwd = makeTempDir();
   initGitRepo(cwd);

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -18,7 +18,7 @@ export function run(command, args, options = {}) {
     env: options.env,
     encoding: "utf8",
     input: options.input,
-    shell: process.platform === "win32" && !path.isAbsolute(command),
+    shell: options.shell ?? (process.platform === "win32" && !path.isAbsolute(command)),
     windowsHide: true
   });
 }

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -131,11 +131,34 @@ test("runCommand preserves explicit zero status without a signal", () => {
   assert.equal(result.signal, null);
 });
 
-test("runCommand never enables a shell and keeps metacharacter args discrete", () => {
+test("runCommand honors an explicit shell override", () => {
+  let captured = null;
+
+  runCommand("git", ["status"], {
+    shell: false,
+    spawnSyncImpl(command, args, options) {
+      captured = { command, args, options };
+      return {
+        status: 0,
+        signal: null,
+        stdout: "",
+        stderr: "",
+        error: null
+      };
+    }
+  });
+
+  assert.equal(captured.command, "git");
+  assert.deepEqual(captured.args, ["status"]);
+  assert.equal(captured.options.shell, false);
+});
+
+test("runCommand keeps metacharacter args discrete when shell is disabled", () => {
   let captured = null;
   const maliciousRef = "main&probe.cmd";
 
   runCommand("git", ["merge-base", "HEAD", maliciousRef], {
+    shell: false,
     spawnSyncImpl(command, args, options) {
       captured = { command, args, options };
       return {

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -130,3 +130,27 @@ test("runCommand preserves explicit zero status without a signal", () => {
   assert.equal(result.status, 0);
   assert.equal(result.signal, null);
 });
+
+test("runCommand never enables a shell and keeps metacharacter args discrete", () => {
+  let captured = null;
+  const maliciousRef = "main&probe.cmd";
+
+  runCommand("git", ["merge-base", "HEAD", maliciousRef], {
+    spawnSyncImpl(command, args, options) {
+      captured = { command, args, options };
+      return {
+        status: 0,
+        signal: null,
+        stdout: "abc123\n",
+        stderr: "",
+        error: null
+      };
+    }
+  });
+
+  assert.equal(captured.command, "git");
+  assert.deepEqual(captured.args, ["merge-base", "HEAD", maliciousRef]);
+  assert.equal(captured.options.shell, false);
+  assert.equal(captured.args[2], maliciousRef);
+  assert.ok(!captured.args.some((arg) => arg === "probe.cmd"));
+});


### PR DESCRIPTION
## Summary

Fixes **EXSECRE-1190** / HackerOne #3904051 using the same approach as [openai/codex-plugin-cc#447](https://github.com/openai/codex-plugin-cc/pull/447).

On Windows, `runCommand()` historically used `shell: true` so tool CLIs exposed as `.cmd` shims can resolve. That is still useful for non-git binaries, but Git receives repository-derived refs (e.g. default branch `main&probe.cmd`). With `shell: true`, Node concatenates argv without escaping (DEP0190), so `cmd.exe` can run a tracked batch file during documented read-only `/grok-build:review` / `/grok-build:critique` **before** Grok’s sandbox starts.

### Changes

- Allow `options.shell` on `runCommand`; default remains Windows `shell: true` (or `SHELL`) / non-Windows `false`.
- Force `shell: false` in `git()` / `gitChecked()`, **after** spreading caller options so it cannot be re-enabled.
- Integration regression: default branch `main&branch-helper&x` + tracked `branch-helper.cmd`; assert review context works and the helper marker is not created.
- Unit coverage for explicit `shell` override and discrete metacharacter args when shell is off.
- Version **0.2.1**.

### Why not blanket `shell: false`?

Codex kept shell for `.cmd` shim discovery and only hardened the Git path. Same rationale here: confine the fix to the command path that takes repository-controlled refs, without changing Windows launch behavior for other fixed binaries that may need a shell.

## Test plan

- [x] `node --test tests/*.test.mjs` (61/61 pass)
- [x] Git integration test with `&` in default branch
- [ ] Optional native Windows smoke with a real `.cmd` payload

Refs: EXSECRE-1190 · https://linear.app/xai-linear/issue/EXSECRE-1190 · inspired by https://github.com/openai/codex-plugin-cc/pull/447