### PR TITLE
fix: pass --prompt-file through to the grok CLI instead of inlining the prompt

### DIFF
--- a/plugins/grok-build/scripts/grok-bridge.mjs
+++ b/plugins/grok-build/scripts/grok-bridge.mjs
@@ -444,6 +444,7 @@ async function executeTaskRun(request) {
 
   const result = await runHeadlessAgent(workspaceRoot, {
     prompt,
+    promptFile: request.promptFile ?? null,
     resumeSessionId,
     model: request.model,
     effort: request.effort,
@@ -547,12 +548,13 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, promptFile, write, resumeLast, jobId }) {
   return {
     cwd,
     model,
     effort,
     prompt,
+    promptFile,
     write,
     resumeLast,
     jobId
@@ -590,11 +592,14 @@ async function executeTransfer(cwd, options = {}) {
 
 function readTaskPrompt(cwd, options, positionals) {
   if (options["prompt-file"]) {
-    return fs.readFileSync(path.resolve(cwd, options["prompt-file"]), "utf8");
+    const promptFile = path.resolve(cwd, options["prompt-file"]);
+    // The contents are only used for validation and job metadata; the grok CLI
+    // reads the file itself via --prompt-file so the prompt never enters argv.
+    return { prompt: fs.readFileSync(promptFile, "utf8"), promptFile };
   }
 
   const positionalPrompt = positionals.join(" ");
-  return positionalPrompt || readStdinIfPiped();
+  return { prompt: positionalPrompt || readStdinIfPiped(), promptFile: null };
 }
 
 function requireTaskRequest(prompt, resumeLast) {
@@ -746,7 +751,7 @@ async function handleTask(argv) {
   const workspaceRoot = resolveCommandWorkspace(options);
   const model = options.model ? String(options.model).trim() : null;
   const effort = normalizeReasoningEffort(options.effort);
-  const prompt = readTaskPrompt(cwd, options, positionals);
+  const { prompt, promptFile } = readTaskPrompt(cwd, options, positionals);
 
   const resumeLast = Boolean(options["resume-last"] || options.resume);
   const fresh = Boolean(options.fresh);
@@ -771,6 +776,7 @@ async function handleTask(argv) {
         model,
         effort,
         prompt,
+        promptFile,
         write,
         resumeLast,
         jobId: job.id
@@ -790,6 +796,7 @@ async function handleTask(argv) {
         model,
         effort,
         prompt,
+        promptFile,
         write,
         resumeLast,
         jobId: job.id,

--- a/plugins/grok-build/scripts/lib/grok.mjs
+++ b/plugins/grok-build/scripts/lib/grok.mjs
@@ -163,7 +163,13 @@ function buildHeadlessArgs(prompt, options = {}) {
     args.push("--session-id", options.sessionId);
   }
 
-  args.push("-p", prompt);
+  if (options.promptFile) {
+    // Keep file-based prompts out of argv: inlining them trips the Windows
+    // 32,767-char command-line limit and exposes the prompt in process listings.
+    args.push("--prompt-file", options.promptFile);
+  } else {
+    args.push("-p", prompt);
+  }
 
   if (options.cwd) {
     args.push("--cwd", options.cwd);

--- a/tests/fake-grok-fixture.mjs
+++ b/tests/fake-grok-fixture.mjs
@@ -77,14 +77,20 @@ if (argv[0] === "import") {
 
 // Headless print / prompt modes
 const printIndex = argv.indexOf("-p");
-const isPrint = printIndex !== -1 || hasFlag("--print");
+const promptFilePath = flagValue("--prompt-file");
+const isPrint = printIndex !== -1 || promptFilePath !== null || hasFlag("--print");
 if (isPrint || hasFlag("-r") || hasFlag("--resume") || hasFlag("-c") || hasFlag("--continue")) {
   if (scenario === "fail-print") {
     process.stderr.write("fake grok failed the print run\\n");
     process.exit(2);
   }
 
-  const prompt = printIndex !== -1 ? (argv[printIndex + 1] ?? "") : "";
+  const prompt =
+    printIndex !== -1
+      ? (argv[printIndex + 1] ?? "")
+      : promptFilePath
+        ? fs.readFileSync(promptFilePath, "utf8")
+        : "";
   const wantsJson = hasFlag("--json-schema") || flagValue("--output-format") === "json";
 
   if (wantsJson || /critique|adversarial|structured|Return only valid JSON/i.test(prompt)) {

--- a/tests/grok-cli.test.mjs
+++ b/tests/grok-cli.test.mjs
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -70,6 +71,28 @@ test("runHeadlessAgent captures stdout and session id from fake grok", async () 
   assert.ok(result.args.includes("-p"));
   assert.ok(result.args.includes("--permission-mode"));
   assert.ok(result.args.includes("plan"));
+});
+
+test("runHeadlessAgent forwards a prompt file path instead of inlining the prompt", async () => {
+  const binDir = makeTempDir();
+  installFakeGrok(binDir);
+  const env = buildEnv(binDir);
+  const cwd = makeTempDir();
+  const promptFile = path.join(cwd, "prompt.txt");
+  fs.writeFileSync(promptFile, "prompt loaded from a file\n");
+
+  const result = await runHeadlessAgent(cwd, {
+    prompt: "prompt loaded from a file\n",
+    promptFile,
+    env,
+    sandbox: "read-only"
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.finalMessage, /Handled the requested task/);
+  assert.ok(result.args.includes("--prompt-file"));
+  assert.equal(result.args[result.args.indexOf("--prompt-file") + 1], promptFile);
+  assert.ok(!result.args.includes("-p"));
 });
 
 test("runImport parses session id from fake grok json output", () => {
@@ -145,6 +168,7 @@ test("live grok --help advertises headless flags when grok is on PATH", () => {
   const text = `${help.stdout}\n${help.stderr}`;
   for (const flag of [
     "-p",
+    "--prompt-file",
     "--single",
     "-r",
     "--resume",

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -238,6 +238,44 @@ test("run delegates through fake grok and stores a finished job", () => {
   }
 });
 
+test("run --prompt-file forwards the path to grok instead of inlining the prompt", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const pluginDataDir = makeTempDir();
+  const fakeGrokLog = path.join(pluginDataDir, "fake-grok.log");
+  installFakeGrok(binDir);
+  initGitRepo(repo);
+
+  // Large enough that inlining it into argv would exceed the Windows
+  // CreateProcess command-line limit (32,767 chars) and fail the spawn.
+  const promptFile = path.join(repo, "prompt.txt");
+  fs.writeFileSync(promptFile, `summarize this repository\n${"x".repeat(40000)}\n`);
+
+  const result = run("node", [SCRIPT, "run", "--prompt-file", promptFile], {
+    cwd: repo,
+    env: pluginDataEnv(pluginDataDir, binDir, { FAKE_GROK_LOG: fakeGrokLog })
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Handled the requested task/);
+
+  const lines = fs
+    .readFileSync(fakeGrokLog, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  const promptRun = [...lines].reverse().find((entry) => entry.argv?.includes("--prompt-file"));
+  assert.ok(promptRun, "expected a headless grok --prompt-file invocation");
+  const argv = promptRun.argv;
+  assert.equal(argv[argv.indexOf("--prompt-file") + 1], promptFile);
+  assert.ok(!argv.includes("-p"));
+  assert.ok(
+    argv.every((arg) => !arg.includes("xxxx")),
+    "prompt contents must not appear in argv"
+  );
+});
+
 test("runs and show surface the latest finished run", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
Refs #14.

`run --prompt-file` reads the file and splices the contents into argv as `-p`. On Windows the spawn dies with ENAMETOOLONG once the assembled command line crosses 32,767 chars (measured boundary: a 32,339-char prompt on my machine), and at any size the full prompt sits readable in process listings for the lifetime of the run. Measurements and repro details are in #14.

This change forwards the resolved path as `--prompt-file`, which the grok CLI accepts natively. The bridge still reads the file locally, since validation and job metadata (title/summary) want the text, but the contents stay out of argv.

What changed:

- `buildHeadlessArgs` pushes `--prompt-file <path>` instead of `-p <contents>` when a prompt file was given. Positional and stdin prompts keep using `-p`.
- `readTaskPrompt` returns the resolved path along with the contents, and both foreground and background (`run-worker`) requests carry it through.
- The fake grok fixture understands `--prompt-file`, so headless tests can cover the flow.
- Tests: a unit test that `runHeadlessAgent` forwards the path and drops `-p`, an end-to-end `run --prompt-file` test with a 40 KB file (fails at spawn on Windows without this fix), and `--prompt-file` added to the live `grok --help` flag check.

One behavior note: a background job now stores the prompt-file path in its request, and the worker hands that path to grok. Enqueue spawns the worker synchronously in the same call, but the file does need to still exist when grok reads it, where before this change the contents were baked into the stored request.

Testing: full suite passes on ubuntu with Node 22 (ran it through Actions on my fork, since this repo has no CI config). On Windows the fixture's extension-less fake `grok` cannot spawn (pre-existing, affects main too), so I verified there with a stub exe: the 40 KB prompt file goes from exit 1 (spawn ENAMETOOLONG) to exit 0 with this change, and the child's live command line drops from 2,352 chars containing the whole prompt to 598 chars containing the path.
