### PR TITLE
fix: fail loud when a delegated run performs no work

### DIFF
--- a/plugins/grok-build/agents/grok-delegate.md
+++ b/plugins/grok-build/agents/grok-delegate.md
@@ -19,8 +19,13 @@ Selection guidance:
 Forwarding rules:
 
 - Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/grok-bridge.mjs" run ...`.
-- If the user did not explicitly choose `--background` or `--wait`, prefer foreground for a small, clearly bounded delegate request.
-- If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Grok running for a long time, prefer background execution and ensure the bridge call uses `--background`.
+- Run in the foreground by default. Do NOT add `--background` unless the user explicitly asked for a background run.
+  Foreground is the default even when the task looks complicated, open-ended, multi-step, or long-running: a run id is
+  not a result, and returning one lets a caller record work that never happened (fleet#254; fleet#34 is the same shape
+  in the sibling CLI bridge). Blocking on the result is the whole value of this subagent.
+- If — and only if — the user explicitly asked for `--background`, the first line of your reply must state that NO
+  RESULT IS AVAILABLE YET and that the run id is a pointer, not an outcome. Never present a queued-launch message as
+  though the task were finished.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, stop runs, summarize output, or do any follow-up work of your own.
 - Do not call `review`, `critique`, `runs`, `show`, or `stop`. This subagent only forwards to `run`.
 - Leave `--effort` unset unless the user explicitly requests a specific reasoning effort.
@@ -34,7 +39,11 @@ Forwarding rules:
 - Otherwise forward the task as a fresh `run`.
 - Preserve the user's task text as-is apart from stripping routing flags.
 - Return the stdout of the `grok-bridge` command exactly as-is.
-- If the Bash call fails or Grok cannot be invoked, return nothing.
+- The bridge exits 3 when it detects an empty run (the delegate described the task instead of doing it). If the Bash
+  call exits non-zero, or stdout carries an `EMPTY RUN` or `UNVERIFIED RUN` banner, return that stdout AND state
+  plainly on the first line that the delegate run FAILED and produced no usable result. Never summarise it away.
+- If the Bash call fails or Grok cannot be invoked, report the failure and the error text. Do not return nothing:
+  silence is indistinguishable from success to the caller.
 
 Response style:
 

--- a/plugins/grok-build/scripts/grok-bridge.mjs
+++ b/plugins/grok-build/scripts/grok-bridge.mjs
@@ -33,6 +33,7 @@ import {
   sortJobsNewestFirst
 } from "./lib/job-control.mjs";
 import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
+import { assessWorkEvidence, renderWorkEvidenceBanner } from "./lib/work-evidence.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
 import {
   claimJobTerminal,
@@ -442,6 +443,7 @@ async function executeTaskRun(request) {
   const prompt = String(request.prompt ?? "").trim() || (resumeSessionId ? DEFAULT_CONTINUE_PROMPT : "");
   const write = Boolean(request.write);
 
+  const startedAtMs = Date.now();
   const result = await runHeadlessAgent(workspaceRoot, {
     prompt,
     resumeSessionId,
@@ -453,27 +455,47 @@ async function executeTaskRun(request) {
     // is safe in both the write and read-only cases here.
     alwaysApprove: true,
     sandbox: write ? undefined : "read-only",
-    outputFormat: "plain",
+    // fleet#254: "plain" discards num_turns/stopReason/usage, leaving the bridge with nothing
+    // but the process exit code to judge completion by. Ask for the envelope instead.
+    outputFormat: "json",
     onProgress: request.onProgress
   });
+  const durationMs = Date.now() - startedAtMs;
 
   const rawOutput = typeof result.finalMessage === "string" ? result.finalMessage : "";
   const failureMessage = result.status === 0 ? "" : result.stderr || "";
-  const rendered = renderTaskResult(
-    {
-      rawOutput,
-      failureMessage
-    },
-    {
-      title: taskMetadata.title,
-      jobId: request.jobId ?? null,
-      write
-    }
-  );
+
+  // fleet#254: a run that emitted a plan and stopped must not be reported as completed.
+  const workVerdict = assessWorkEvidence({
+    telemetry: result.telemetry,
+    text: rawOutput,
+    durationMs,
+    requireWork: request.requireWork !== false,
+    strict: Boolean(request.strictWorkEvidence)
+  });
+
+  const rendered =
+    renderTaskResult(
+      {
+        rawOutput,
+        failureMessage
+      },
+      {
+        title: taskMetadata.title,
+        jobId: request.jobId ?? null,
+        write
+      }
+    ) + renderWorkEvidenceBanner(workVerdict);
   const payload = {
     status: result.status,
     threadId: result.threadId,
-    rawOutput
+    rawOutput,
+    workEvidence: workVerdict.evidence,
+    workVerdict: {
+      noWork: workVerdict.noWork,
+      unverified: workVerdict.unverified,
+      reasons: workVerdict.reasons
+    }
   };
 
   return {
@@ -482,7 +504,10 @@ async function executeTaskRun(request) {
     turnId: null,
     payload,
     rendered,
-    summary: firstMeaningfulLine(rawOutput, firstMeaningfulLine(failureMessage, `${taskMetadata.title} finished.`)),
+    workVerdict,
+    summary: workVerdict.noWork
+      ? `EMPTY RUN (no work performed): ${firstMeaningfulLine(rawOutput, taskMetadata.title)}`
+      : firstMeaningfulLine(rawOutput, firstMeaningfulLine(failureMessage, `${taskMetadata.title} finished.`)),
     jobTitle: taskMetadata.title,
     jobClass: "task",
     write
@@ -547,7 +572,17 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({
+  cwd,
+  model,
+  effort,
+  prompt,
+  write,
+  resumeLast,
+  jobId,
+  requireWork = true,
+  strictWorkEvidence = false
+}) {
   return {
     cwd,
     model,
@@ -555,7 +590,10 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
-    jobId
+    jobId,
+    // fleet#254: persisted into the queued request so background runs enforce the same gate.
+    requireWork,
+    strictWorkEvidence
   };
 }
 
@@ -612,6 +650,10 @@ async function runForegroundCommand(job, runner, options = {}) {
   outputResult(options.json ? execution.payload : execution.rendered, options.json);
   if (execution.exitStatus !== 0) {
     process.exitCode = execution.exitStatus;
+  } else if (execution.workVerdict?.noWork) {
+    // fleet#254: an empty run must be visible to the shell that invoked the bridge, not just
+    // in the job record. The delegate subagent only sees this exit code and stdout.
+    process.exitCode = 3;
   }
   return execution;
 }
@@ -736,7 +778,17 @@ async function handleReview(argv) {
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["model", "effort", "cwd", "prompt-file"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+    booleanOptions: [
+      "json",
+      "write",
+      "resume-last",
+      "resume",
+      "fresh",
+      "background",
+      // fleet#254 work-evidence gate controls.
+      "allow-no-work",
+      "strict-work-evidence"
+    ],
     aliasMap: {
       m: "model"
     }
@@ -754,6 +806,8 @@ async function handleTask(argv) {
     throw new Error("Choose either --resume/--resume-last or --fresh.");
   }
   const write = Boolean(options.write);
+  const requireWork = !options["allow-no-work"];
+  const strictWorkEvidence = Boolean(options["strict-work-evidence"]);
   const taskMetadata = buildTaskRunMetadata({
     prompt,
     resumeLast
@@ -773,7 +827,9 @@ async function handleTask(argv) {
         prompt,
         write,
         resumeLast,
-        jobId: job.id
+        jobId: job.id,
+        requireWork,
+        strictWorkEvidence
       })
     };
     const { payload } = enqueueBackgroundJob(cwd, job, request);
@@ -793,6 +849,8 @@ async function handleTask(argv) {
         write,
         resumeLast,
         jobId: job.id,
+        requireWork,
+        strictWorkEvidence,
         onProgress: progress
       }),
     { json: options.json }

--- a/plugins/grok-build/scripts/lib/grok.mjs
+++ b/plugins/grok-build/scripts/lib/grok.mjs
@@ -6,6 +6,7 @@ import process from "node:process";
 
 import { readJsonFile } from "./fs.mjs";
 import { binaryAvailable, runCommand } from "./process.mjs";
+import { extractRunTelemetry } from "./work-evidence.mjs";
 
 export const DEFAULT_CONTINUE_PROMPT =
   "Continue from the current thread state. Pick the next highest-value step and follow through until the task is resolved.";
@@ -260,6 +261,10 @@ export function runHeadlessAgent(cwd, options = {}) {
         status === 0 ? "finalizing" : "failed",
         { threadId: sessionId, agentPid }
       );
+      // fleet#254: recover run telemetry (num_turns / stopReason / usage) when the caller asked
+      // for a structured output format. Telemetry is null for plain runs, and a null telemetry
+      // must never be read as "the run did work".
+      const { text: finalMessage, telemetry } = extractRunTelemetry(stdout);
       resolve({
         status,
         signal,
@@ -268,7 +273,8 @@ export function runHeadlessAgent(cwd, options = {}) {
         sessionId,
         threadId: sessionId,
         agentPid,
-        finalMessage: stdout.trimEnd(),
+        finalMessage,
+        telemetry,
         args,
         binary
       });

--- a/plugins/grok-build/scripts/lib/tracked-jobs.mjs
+++ b/plugins/grok-build/scripts/lib/tracked-jobs.mjs
@@ -229,17 +229,38 @@ export async function runTrackedJob(job, runner, options = {}) {
 
   try {
     const execution = await runner();
-    const completionStatus = execution.exitStatus === 0 ? "completed" : "failed";
+
+    // fleet#254: a zero exit code reports process health, not work completion. A run whose model
+    // emitted a plan and ended its turn exits 0 exactly like a run that did the job. Demote such
+    // a run to `failed` so no caller can read `completed` as evidence of work.
+    const workVerdict = execution.workVerdict ?? null;
+    const emptyRun = Boolean(workVerdict?.noWork);
+    const completionStatus = execution.exitStatus === 0 && !emptyRun ? "completed" : "failed";
+    if (emptyRun) {
+      appendLogLine(
+        options.logFile ?? job.logFile ?? null,
+        `EMPTY RUN: marking ${job.id} FAILED despite exit ${execution.exitStatus}. ${(workVerdict.reasons ?? []).join(" ")}`
+      );
+    } else if (workVerdict?.unverified) {
+      appendLogLine(
+        options.logFile ?? job.logFile ?? null,
+        `UNVERIFIED RUN: ${job.id} produced no work telemetry; completion is not evidence of work.`
+      );
+    }
+
     const claim = claimJobTerminal(job.workspaceRoot, job.id, completionStatus, {
       threadId: execution.threadId ?? null,
       turnId: execution.turnId ?? null,
       summary: execution.summary,
       result: execution.payload,
       rendered: execution.rendered,
+      workEvidence: workVerdict?.evidence ?? null,
+      emptyRun,
       bridgePid,
       agentPid: null,
       pid: null,
       phase: completionStatus === "completed" ? "done" : "failed",
+      errorMessage: emptyRun ? (workVerdict.reasons ?? []).join(" ") : undefined,
       logFile: options.logFile ?? job.logFile ?? null
     });
 

--- a/plugins/grok-build/scripts/lib/work-evidence.mjs
+++ b/plugins/grok-build/scripts/lib/work-evidence.mjs
@@ -1,0 +1,168 @@
+/**
+ * Work-evidence assessment for Grok bridge runs (fleet#254).
+ *
+ * The bridge previously treated "the grok process exited 0" as "the delegate did the work".
+ * A process exit code reports process health, never work completion: a run in which the model
+ * emitted a one-sentence plan and ended its turn exits 0 exactly like a run that did the job.
+ *
+ * The Grok CLI already computes the discriminating signal, but only when asked for a structured
+ * output format. `--output-format json` emits an envelope containing `num_turns`, `stopReason`
+ * and `usage`. `num_turns === 1` means the model produced a single assistant turn with no tool
+ * round-trip -- i.e. it described the work instead of doing it.
+ *
+ * These signals are computed by the CLI runtime, not authored by the model, so they cannot be
+ * asserted away in prose. That is the property that makes them usable as a gate.
+ */
+
+/** Keys that identify a Grok headless JSON envelope rather than a schema-constrained payload. */
+const ENVELOPE_KEYS = ["num_turns", "stopReason", "usage", "requestId"];
+
+/**
+ * Tolerantly split a headless stdout blob into assistant text plus run telemetry.
+ *
+ * Returns `telemetry: null` when stdout is not a JSON envelope (plain output format, or a
+ * `--json-schema` run whose stdout is the schema payload itself). Callers must treat a null
+ * telemetry as "unverified", never as "verified good".
+ *
+ * @param {string} stdout raw stdout from the grok headless process
+ * @returns {{ text: string, telemetry: null | { numTurns: number|null, stopReason: string|null, outputTokens: number|null, totalTokens: number|null, modelCalls: number|null } }}
+ */
+export function extractRunTelemetry(stdout) {
+  const text = typeof stdout === "string" ? stdout : "";
+  const trimmed = text.trim();
+  if (!trimmed || (trimmed[0] !== "{" && trimmed[0] !== "[")) {
+    return { text: text.trimEnd(), telemetry: null };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return { text: text.trimEnd(), telemetry: null };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { text: text.trimEnd(), telemetry: null };
+  }
+
+  const looksLikeEnvelope = ENVELOPE_KEYS.some((key) => Object.hasOwn(parsed, key));
+  if (!looksLikeEnvelope) {
+    // A schema-constrained payload. Preserve the original bytes so structured parsing still works.
+    return { text: text.trimEnd(), telemetry: null };
+  }
+
+  const usage = parsed.usage && typeof parsed.usage === "object" ? parsed.usage : {};
+  let modelCalls = null;
+  if (parsed.modelUsage && typeof parsed.modelUsage === "object") {
+    for (const entry of Object.values(parsed.modelUsage)) {
+      if (entry && typeof entry.modelCalls === "number") {
+        modelCalls = (modelCalls ?? 0) + entry.modelCalls;
+      }
+    }
+  }
+
+  const envelopeText = typeof parsed.text === "string" ? parsed.text : text.trimEnd();
+
+  return {
+    text: envelopeText,
+    telemetry: {
+      numTurns: typeof parsed.num_turns === "number" ? parsed.num_turns : null,
+      stopReason: typeof parsed.stopReason === "string" ? parsed.stopReason : null,
+      outputTokens: typeof usage.output_tokens === "number" ? usage.output_tokens : null,
+      totalTokens: typeof usage.total_tokens === "number" ? usage.total_tokens : null,
+      modelCalls
+    }
+  };
+}
+
+/**
+ * Decide whether a finished run carries positive evidence that work happened.
+ *
+ * Three outcomes, deliberately distinct:
+ *  - `noWork: true`      proof of no work (a tool-free single turn). Terminal status must be failed.
+ *  - `unverified: true`  the run produced no telemetry, so nothing is known. Surfaced loudly,
+ *                        and failed only under `strict`.
+ *  - neither             positive evidence of at least one tool round-trip.
+ *
+ * Duration is deliberately NOT a gate. A short run can be a correct answer to a small question,
+ * and a duration floor converts this false-success into a false-failure -- the same
+ * invert-the-error trade this fix exists to avoid. Duration is recorded for forensics only.
+ *
+ * @param {object} args
+ * @param {ReturnType<typeof extractRunTelemetry>["telemetry"]} args.telemetry
+ * @param {string} [args.text]
+ * @param {number|null} [args.durationMs]
+ * @param {boolean} [args.requireWork] enforce the gate at all (default true)
+ * @param {boolean} [args.strict] also fail when telemetry is unavailable (default false)
+ */
+export function assessWorkEvidence({
+  telemetry,
+  text = "",
+  durationMs = null,
+  requireWork = true,
+  strict = false
+} = {}) {
+  const evidence = {
+    numTurns: telemetry?.numTurns ?? null,
+    stopReason: telemetry?.stopReason ?? null,
+    outputTokens: telemetry?.outputTokens ?? null,
+    modelCalls: telemetry?.modelCalls ?? null,
+    outputChars: typeof text === "string" ? text.trim().length : 0,
+    durationMs,
+    telemetryAvailable: Boolean(telemetry)
+  };
+
+  if (!requireWork) {
+    return { noWork: false, unverified: false, reasons: [], evidence, enforced: false };
+  }
+
+  const reasons = [];
+
+  if (!telemetry || telemetry.numTurns === null) {
+    reasons.push(
+      "No run telemetry was returned, so it cannot be shown that the delegate did any work."
+    );
+    return { noWork: strict, unverified: true, reasons, evidence, enforced: true };
+  }
+
+  if (telemetry.numTurns <= 1) {
+    reasons.push(
+      `The delegate produced ${telemetry.numTurns} assistant turn and made no tool calls: it described the task instead of performing it.`
+    );
+  }
+
+  if (evidence.outputChars === 0) {
+    reasons.push("The delegate returned no output text.");
+  }
+
+  return { noWork: reasons.length > 0, unverified: false, reasons, evidence, enforced: true };
+}
+
+/**
+ * Human-readable banner appended to the rendered result so a caller reading only the
+ * rendered text cannot miss an empty run.
+ */
+export function renderWorkEvidenceBanner(verdict) {
+  if (!verdict || !verdict.enforced) {
+    return "";
+  }
+  if (verdict.noWork) {
+    return [
+      "",
+      "!! EMPTY RUN -- NO WORK PERFORMED (fleet#254 guard) !!",
+      ...verdict.reasons.map((reason) => `- ${reason}`),
+      "This run is marked FAILED. Do not treat its output as a result.",
+      ""
+    ].join("\n");
+  }
+  if (verdict.unverified) {
+    return [
+      "",
+      "!! UNVERIFIED RUN -- no work telemetry available (fleet#254 guard) !!",
+      ...verdict.reasons.map((reason) => `- ${reason}`),
+      "Completion status is not evidence that the task was performed.",
+      ""
+    ].join("\n");
+  }
+  return "";
+}

--- a/tests/fake-grok-fixture.mjs
+++ b/tests/fake-grok-fixture.mjs
@@ -85,7 +85,28 @@ if (isPrint || hasFlag("-r") || hasFlag("--resume") || hasFlag("-c") || hasFlag(
   }
 
   const prompt = printIndex !== -1 ? (argv[printIndex + 1] ?? "") : "";
-  const wantsJson = hasFlag("--json-schema") || flagValue("--output-format") === "json";
+  const wantsSchema = hasFlag("--json-schema");
+  const wantsEnvelope = !wantsSchema && flagValue("--output-format") === "json";
+  const wantsJson = wantsSchema || flagValue("--output-format") === "json";
+
+  // fleet#254: the delegate path now asks for --output-format json, so the fake must emit the
+  // real CLI's envelope (text + num_turns + usage). The "empty-run" scenario reproduces the
+  // defect: a single tool-free turn that still exits 0.
+  if (wantsEnvelope) {
+    const emptyRun = scenario === "empty-run";
+    const envelope = {
+      text: emptyRun
+        ? "I'll investigate the repository and report back with findings."
+        : "Handled the requested task.",
+      stopReason: "end_turn",
+      sessionId: "11111111-2222-4333-8444-555555555555",
+      usage: { input_tokens: 100, output_tokens: emptyRun ? 30 : 200, total_tokens: 300 },
+      num_turns: emptyRun ? 1 : 3,
+      modelUsage: { "fake-model": { modelCalls: emptyRun ? 1 : 3 } }
+    };
+    process.stdout.write(JSON.stringify(envelope) + "\\n");
+    process.exit(0);
+  }
 
   if (wantsJson || /critique|adversarial|structured|Return only valid JSON/i.test(prompt)) {
     const payload = {

--- a/tests/work-evidence.test.mjs
+++ b/tests/work-evidence.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assessWorkEvidence,
+  extractRunTelemetry,
+  renderWorkEvidenceBanner
+} from "../plugins/grok-build/scripts/lib/work-evidence.mjs";
+
+// The exact envelope shape emitted by `grok -p ... --output-format json`, captured from the
+// real CLI on 2026-08-06 (grok-4.5-build). num_turns === 1 is a tool-free single turn.
+const EMPTY_RUN_ENVELOPE = JSON.stringify({
+  text: "I'll run an adversarial review of PR #250 in isolation: fetch the PR/issue, clone the branch under /tmp, then attack the six claimed risk areas with concrete evidence only.",
+  stopReason: "end_turn",
+  sessionId: "019fd6fd-828e-7de3-bb52-61347d34dc03",
+  requestId: "ab9f08dc-8c9e-4f6d-b697-fb6e6bfcdd49",
+  usage: { input_tokens: 20400, output_tokens: 77, total_tokens: 51453 },
+  num_turns: 1,
+  total_cost_usd: 0.05,
+  modelUsage: { "grok-4.5-build": { modelCalls: 1 } }
+});
+
+const REAL_RUN_ENVELOPE = JSON.stringify({
+  text: "## Directory inventory\n| Path | Type |\n...\nVERDICT: DO_NOT_MERGE",
+  stopReason: "end_turn",
+  usage: { input_tokens: 20400, output_tokens: 472, total_tokens: 60000 },
+  num_turns: 3,
+  modelUsage: { "grok-4.5-build": { modelCalls: 3 } }
+});
+
+test("extractRunTelemetry recovers num_turns and text from a headless JSON envelope", () => {
+  const { text, telemetry } = extractRunTelemetry(EMPTY_RUN_ENVELOPE);
+  assert.equal(telemetry.numTurns, 1);
+  assert.equal(telemetry.stopReason, "end_turn");
+  assert.equal(telemetry.outputTokens, 77);
+  assert.equal(telemetry.modelCalls, 1);
+  assert.match(text, /^I'll run an adversarial review/);
+});
+
+test("extractRunTelemetry leaves plain output untouched and reports no telemetry", () => {
+  const { text, telemetry } = extractRunTelemetry("Handled the requested task.\n");
+  assert.equal(telemetry, null);
+  assert.equal(text, "Handled the requested task.");
+});
+
+test("extractRunTelemetry does not mistake a --json-schema payload for an envelope", () => {
+  const payload = JSON.stringify({ verdict: "approve", findings: [], summary: "fine" });
+  const { text, telemetry } = extractRunTelemetry(payload);
+  assert.equal(telemetry, null, "schema payloads carry no run telemetry");
+  assert.equal(text, payload, "schema payload bytes must survive for structured parsing");
+});
+
+test("fleet#254: an intent-only run is proven empty and must not pass", () => {
+  const { text, telemetry } = extractRunTelemetry(EMPTY_RUN_ENVELOPE);
+  const verdict = assessWorkEvidence({ telemetry, text, durationMs: 7215 });
+  assert.equal(verdict.noWork, true);
+  assert.equal(verdict.unverified, false);
+  assert.equal(verdict.evidence.numTurns, 1);
+  assert.match(verdict.reasons.join(" "), /described the task instead of performing it/);
+  assert.match(renderWorkEvidenceBanner(verdict), /EMPTY RUN/);
+});
+
+test("a run with tool round-trips passes", () => {
+  const { text, telemetry } = extractRunTelemetry(REAL_RUN_ENVELOPE);
+  const verdict = assessWorkEvidence({ telemetry, text, durationMs: 268056 });
+  assert.equal(verdict.noWork, false);
+  assert.equal(verdict.unverified, false);
+  assert.equal(renderWorkEvidenceBanner(verdict), "");
+});
+
+test("a fast but genuine run is NOT failed — duration is never a gate", () => {
+  // run-msgdxv4t-g9mcvz answered a four-command question correctly in 3.4s. A duration floor
+  // would invert this fix's error, turning a false success into a false failure.
+  const envelope = JSON.stringify({
+    text: "1. /home/psimmons/worktrees/ops-plans-a7\n2. clean\n3. abc123\n4. main",
+    stopReason: "end_turn",
+    usage: { output_tokens: 40 },
+    num_turns: 2
+  });
+  const { text, telemetry } = extractRunTelemetry(envelope);
+  const verdict = assessWorkEvidence({ telemetry, text, durationMs: 3391 });
+  assert.equal(verdict.noWork, false, "short duration alone must never fail a run");
+});
+
+test("missing telemetry is reported as unverified, never as verified-good", () => {
+  const verdict = assessWorkEvidence({ telemetry: null, text: "Handled the requested task." });
+  assert.equal(verdict.unverified, true);
+  assert.equal(verdict.noWork, false, "unknown is not proof of absence by default");
+  assert.match(renderWorkEvidenceBanner(verdict), /UNVERIFIED RUN/);
+});
+
+test("strict mode fails an unverifiable run", () => {
+  const verdict = assessWorkEvidence({ telemetry: null, text: "ok", strict: true });
+  assert.equal(verdict.noWork, true);
+});
+
+test("--allow-no-work disables the gate entirely for genuine tool-free analysis", () => {
+  const { text, telemetry } = extractRunTelemetry(EMPTY_RUN_ENVELOPE);
+  const verdict = assessWorkEvidence({ telemetry, text, requireWork: false });
+  assert.equal(verdict.noWork, false);
+  assert.equal(verdict.enforced, false);
+  assert.equal(renderWorkEvidenceBanner(verdict), "");
+});


### PR DESCRIPTION
## Summary

A delegated run that performs **no work at all** is currently reported to Claude Code as `completed`, with the model's preamble as its "result". The caller has no way to tell that apart from a real answer.

We hit this on a delegated code review: the run finished in 7.2s, returned the single sentence *"I'll run an adversarial review of PR #250 in isolation: fetch the PR/issue, clone the branch under /tmp, then attack."*, and was recorded as a successful run. Nothing was reviewed. We have seen the same shape repeatedly on read-only (`write: false`) delegations.

This PR makes that case fail loudly instead of passing silently.

## The two composing defects

Neither one is sufficient on its own; together they make an empty run indistinguishable from a successful one.

**1. `executeTaskRun` requested `outputFormat: 'plain'`.**

`plain` returns only the final assistant text. It discards the only completion telemetry the Grok CLI emits — `num_turns`, `stopReason`, `usage`, and `modelUsage.modelCalls`. After that call returns, the bridge holds no evidence about whether any tool was ever invoked.

**2. `tracked-jobs.mjs` then derived completion from the process exit code:**

```js
status: execution.exitStatus === 0 ? "completed" : "failed"
```

**A process exit code cannot report work completion.** It reports process health — did the binary start, run, and terminate without crashing. A model that reads the prompt, emits one sentence describing what it intends to do, and ends its turn is a *completely healthy process*: the CLI did its job perfectly and exits 0. The exit code is not a wrong signal here, it is simply not a signal about work at all, and defect 1 had already thrown away the signals that were.

The result is a false green — the failure mode where the delegating agent proceeds as if a review happened.

## Reproduction

With a fake `grok` on `GROK_BINARY` that emits the envelope we actually observed:

```json
{"text":"I'll run an adversarial review of PR #250 in isolation: fetch the PR/issue, clone the branch under /tmp, then attack.",
 "stopReason":"end_turn","usage":{"output_tokens":40},"num_turns":1,
 "modelUsage":{"grok-4.5-build":{"modelCalls":1}}}
```

```
$ FAKE_MODE=empty node plugins/grok-build/scripts/grok-bridge.mjs run "adversarial review of PR 250"
```

- On `main` (92b76a6): **exit 0**, job status `completed`, no warning.
- With this PR: **exit 3**, job status `failed`, `EMPTY RUN` banner.
- With this PR and a multi-turn envelope (`num_turns: 7`): **exit 0**, `completed` — unchanged.

`num_turns == 1` with no tool calls is positive proof of a tool-free single turn. We verified the counter empirically against the real CLI: `1` for a no-tool reply, `2` for one tool round-trip, `3+` for multi-step work.

## What the patch does

`executeTaskRun` switches to `--output-format json`, a new `lib/work-evidence.mjs` extracts the telemetry and classifies the run, and `tracked-jobs.mjs` demotes a proven-empty run to `failed`.

Three outcomes are kept **deliberately distinct** — this is the part we'd most welcome your opinion on:

| Outcome | Meaning | Behavior |
|---|---|---|
| `noWork` | Positive proof of an empty run (telemetry present, shows a tool-free single turn) | **Fails** — exit 3, job `failed`, banner |
| `unverified` | Telemetry unavailable, so the run cannot be judged either way | Loud banner; **fails only under `--strict-work-evidence`** |
| `pass` | Evidence of real work | Unchanged |

`unverified` is separated from `noWork` on purpose: absence of evidence is not evidence of absence, and we did not want an older CLI or an unexpected envelope shape to start failing runs that were fine.

**`--allow-no-work` exempts genuine tool-free analysis** — "explain this concept", "what's the tradeoff between X and Y" — where a single-turn answer with no tool call is exactly correct.

**The review/critique path is deliberately NOT gated.** A tool-free review of a diff supplied in the prompt is legitimate work: the content is already in context and there is nothing to fetch. Gating that path would have generated false failures on correct behavior. Only the delegate/task path is gated.

Signals we deliberately did **not** gate on: the model's own prose or self-declared verdict (gameable — it's exactly what fooled us here), and **wall-clock duration**, which we measured to be unreliable in *both* directions — a 3.4s run answered its question correctly, and a 119s run returned nothing but an intent sentence. A duration floor would have inverted this fix's error. Duration is recorded, never gated.

## Test evidence, exactly as measured

- `npm test` on `main` (92b76a6), unmodified: **64 tests, 63 pass, 1 fail**
- `npm test` with this PR: **73 tests, 72 pass, 1 fail**
- The 9 new tests all pass.
- The single failure is `tests/state.test.mjs:17` *"resolveStateDir uses a temp-backed per-workspace directory"*. It is **pre-existing and unrelated** — it fails identically on unmodified `main` in our environment, before and after this change. We have not investigated it and this PR does not touch it.

The existing suite caught a real defect in an earlier revision of this patch, which we then fixed.

## Limits we want to be honest about

- **The underlying trigger is NOT root-caused.** We do not know why Grok intermittently ends its turn after a preamble. This PR detects and reports the condition; it does not prevent it. It is a guardrail, not a cure.
- **Our leading hypothesis failed.** We suspected `--permission-mode plan`, which the bridge set for every `write: false` run. It **failed to reproduce in 2 controlled experiments** — plan mode used tools and answered correctly both times. The correlation with read-only runs is real in our data; the trigger is nondeterministic and unexplained.
- We note that your 92b76a6 ("headless read-only runs can't auto-approve within their own sandbox") already moved read-only runs from plan mode to `alwaysApprove: true` + `sandbox: "read-only"`. That may well address part of the underlying cause — we have not yet run enough post-92b76a6 volume to say. If it does, we'd argue the detection is still worth having: the point is that the bridge should never again be *unable to notice*.
- **Historical runs cannot be adjudicated.** No tool-call telemetry was ever recorded, so for past runs "did no work" can only be inferred from output shape, not proven. That unprovability is itself part of what this PR fixes going forward.
- **Not exercised:** the `--background` and `--resume-last` paths were tested only via the existing suite, not end-to-end with the gate active. Foreground `run` is what we exercised directly.

## Also included

`agents/grok-delegate.md` currently tells the subagent to prefer `--background` for complex tasks, and separately instructs it not to fetch results or report errors — so it returns a bare run id, and on failure returns nothing. This PR defaults it to foreground, forbids returning a bare run id as if it were a result, and requires it to report failures. This is a smaller and more opinionated change than the rest; happy to split it into its own PR if you'd prefer to consider it separately.

---

Rebased on `main` @ 92b76a6. Merges cleanly. Glad to adjust naming, the exit code, or the strictness defaults to fit your conventions.
