### PR TITLE
fix: stop SessionStart from growing CLAUDE_ENV_FILE without bound

### DIFF
--- a/plugins/grok-build/scripts/session-lifecycle-hook.mjs
+++ b/plugins/grok-build/scripts/session-lifecycle-hook.mjs
@@ -23,11 +23,47 @@ function shellEscape(value) {
   return `'${String(value).replace(/'/g, `'\"'\"'`)}'`;
 }
 
+function isLineForVar(name, line) {
+  const trimmed = line.trim();
+  return trimmed.startsWith(`export ${name}=`) || trimmed.startsWith(`${name}=`);
+}
+
 function appendEnvVar(name, value) {
-  if (!process.env.CLAUDE_ENV_FILE || value == null || value === "") {
+  const file = process.env.CLAUDE_ENV_FILE;
+  if (!file || value == null || value === "") {
     return;
   }
-  fs.appendFileSync(process.env.CLAUDE_ENV_FILE, `export ${name}=${shellEscape(value)}\n`, "utf8");
+
+  // Rewrite this variable rather than append. SessionStart also fires on resume
+  // and compaction; Claude Code inlines CLAUDE_ENV_FILE into every bash -c, and
+  // on Windows MSYS2 silently truncates that argument past 8186 characters.
+  const line = `export ${name}=${shellEscape(value)}\n`;
+
+  let existing = "";
+  try {
+    existing = fs.readFileSync(file, "utf8");
+  } catch (error) {
+    // Only a missing file is empty. Any other read error must abort: the write
+    // below replaces the whole file, and handleSessionStart runs three of these
+    // back to back.
+    if (error?.code !== "ENOENT") {
+      return;
+    }
+  }
+
+  // Drop the empty split tail so a trailing newline cannot re-grow the file by one
+  // byte per call. Exactly one: it is the artefact this split just created.
+  //
+  // Filtering every blank entry instead would also delete blank lines another hook
+  // wrote, and CLAUDE_ENV_FILE is shared. Reformatting someone else's content on
+  // every session start, resume and compaction is a quieter version of the problem
+  // this function exists to fix.
+  const kept = existing.split(/\r?\n/).filter((entry) => !isLineForVar(name, entry));
+  if (kept.length > 0 && kept[kept.length - 1] === "") {
+    kept.pop();
+  }
+  const next = kept.length > 0 ? `${kept.join("\n")}\n${line}` : line;
+  fs.writeFileSync(file, next, "utf8");
 }
 
 function cleanupSessionJobs(cwd, sessionId) {

--- a/tests/session-lifecycle.test.mjs
+++ b/tests/session-lifecycle.test.mjs
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+import { makeTempDir, run } from "./helpers.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const HOOK = path.join(ROOT, "plugins", "grok-build", "scripts", "session-lifecycle-hook.mjs");
+
+function fireSessionStart(envFile, pluginData, sessionId = "sess-1") {
+  return run(process.execPath, [HOOK, "SessionStart"], {
+    env: {
+      ...process.env,
+      CLAUDE_ENV_FILE: envFile,
+      CLAUDE_PLUGIN_DATA: pluginData
+    },
+    input: JSON.stringify({
+      hook_event_name: "SessionStart",
+      session_id: sessionId,
+      transcript_path: "C:\\tmp\\transcript.jsonl"
+    })
+  });
+}
+
+test("repeated SessionStart does not grow CLAUDE_ENV_FILE", () => {
+  // SessionStart fires on start, resume, and compaction. Appending grew the file
+  // without bound; Claude Code inlines the whole file into every bash -c, and
+  // MSYS2 silently truncates past 8186 characters — including false-green exit 0
+  // when the cut lands on a line boundary. Assert a bound, not mere presence.
+  const envFile = path.join(makeTempDir(), "claude-env.sh");
+  const pluginData = makeTempDir();
+
+  assert.equal(fireSessionStart(envFile, pluginData).status, 0);
+  const afterFirst = fs.readFileSync(envFile, "utf8");
+  assert.match(afterFirst, /export GROK_CC_SESSION_ID='sess-1'/);
+
+  for (let i = 0; i < 8; i += 1) {
+    assert.equal(fireSessionStart(envFile, pluginData).status, 0);
+  }
+  const afterMany = fs.readFileSync(envFile, "utf8");
+
+  assert.equal(
+    afterMany.length,
+    afterFirst.length,
+    `nine identical SessionStart events must not grow the file; grew ${afterFirst.length} -> ${afterMany.length}`
+  );
+  for (const name of ["GROK_CC_SESSION_ID", "GROK_CC_TRANSCRIPT_PATH", "CLAUDE_PLUGIN_DATA"]) {
+    const hits = afterMany.split(/\r?\n/).filter((entry) => entry.trim().startsWith(`export ${name}=`));
+    assert.equal(hits.length, 1, `${name} must appear exactly once, found ${hits.length}`);
+  }
+
+  assert.equal(fireSessionStart(envFile, pluginData, "sess-2").status, 0);
+  const afterChange = fs.readFileSync(envFile, "utf8");
+  assert.match(afterChange, /export GROK_CC_SESSION_ID='sess-2'/);
+  assert.doesNotMatch(afterChange, /sess-1/);
+  assert.ok(
+    afterChange.length < 2000,
+    `env file must stay small; MSYS2 bash truncates a -c argument past 8186 chars. Got ${afterChange.length}`
+  );
+});
+
+test("SessionStart rewrites a pre-bloated env file and keeps foreign lines", () => {
+  const envFile = path.join(makeTempDir(), "claude-env.sh");
+  const pluginData = makeTempDir();
+  // Bloat well past whatever the rewritten file will be, so the shrink assertion below
+  // does not depend on the length of os.tmpdir() — the rewritten file embeds a temp path,
+  // and a fixed expectation here fails on any host whose tmpdir is long enough.
+  // GROK_CC_SESSION_ID_BACKUP is a foreign line that shares a prefix with a variable we
+  // own, so a rewrite matching on substring rather than on the full name would eat it.
+  //
+  // The blank line is deliberate too, and for a subtler reason: this fixture was built
+  // entirely from non-empty strings, so a rewrite that dropped EVERY blank entry rather
+  // than just the split's own trailing one passed this test while silently reformatting
+  // any file that did contain blank lines. CLAUDE_ENV_FILE is shared, so those belong to
+  // whoever wrote them. A foreign-content test with no blank content in it cannot see that.
+  const bloated = [
+    "# another hook's header",
+    "export OTHER_HOOK='keep-me'",
+    "",
+    "export GROK_CC_SESSION_ID_BACKUP='keep-me-too'",
+    ...Array.from({ length: 20 }, () => "export GROK_CC_SESSION_ID='old'"),
+    ...Array.from({ length: 20 }, () => "export GROK_CC_TRANSCRIPT_PATH='/tmp/old.jsonl'"),
+    ""
+  ].join("\n");
+  fs.writeFileSync(envFile, bloated, "utf8");
+  const beforeLen = Buffer.byteLength(bloated, "utf8");
+
+  assert.equal(fireSessionStart(envFile, pluginData, "sess-repaired").status, 0);
+  const body = fs.readFileSync(envFile, "utf8");
+
+  assert.match(body, /export OTHER_HOOK='keep-me'/);
+  assert.match(body, /export GROK_CC_SESSION_ID_BACKUP='keep-me-too'/);
+  assert.match(body, /# another hook's header/);
+  assert.match(
+    body,
+    /export OTHER_HOOK='keep-me'\n\nexport GROK_CC_SESSION_ID_BACKUP='keep-me-too'/,
+    "a blank line another hook wrote must survive the rewrite"
+  );
+  assert.match(body, /export GROK_CC_SESSION_ID='sess-repaired'/);
+  assert.equal(
+    body.split(/\r?\n/).filter((entry) => entry.trim().startsWith("export GROK_CC_SESSION_ID=")).length,
+    1
+  );
+  assert.ok(Buffer.byteLength(body, "utf8") < beforeLen, "bloated file must shrink on rewrite");
+
+  // The bound has to hold with foreign blank lines present, not only on a file this hook
+  // owns outright. Dropping exactly one trailing empty is what keeps it: dropping none
+  // re-grows the file by a byte per variable per event, and dropping all of them is the
+  // over-filter this fixture exists to catch. Without this loop the length claim is only
+  // asserted for the easy case.
+  const settled = Buffer.byteLength(body, "utf8");
+  for (let i = 0; i < 5; i += 1) {
+    assert.equal(fireSessionStart(envFile, pluginData, "sess-repaired").status, 0);
+  }
+  assert.equal(
+    Buffer.byteLength(fs.readFileSync(envFile, "utf8"), "utf8"),
+    settled,
+    "repeated events must not grow a file that contains foreign blank lines"
+  );
+});
+
+test("unreadable CLAUDE_ENV_FILE aborts rewrite instead of destroying content", () => {
+  // A directory at the env-file path yields EISDIR (not ENOENT) on read. The rewrite
+  // path must abort rather than treat the failure as empty and whole-file write.
+  const dirAsFile = makeTempDir();
+  const result = fireSessionStart(dirAsFile, makeTempDir(), "sess-unreadable");
+
+  assert.equal(result.status, 0, `hook must survive an unreadable env file: ${result.stderr}`);
+  assert.ok(fs.statSync(dirAsFile).isDirectory(), "the target must be left untouched");
+  assert.deepEqual(fs.readdirSync(dirAsFile), []);
+});


### PR DESCRIPTION
Fixes #18.

## Why this matters

Claude Code inlines the entire contents of `CLAUDE_ENV_FILE` into the `bash -c` argument of every Bash tool call. On Windows, MSYS2 bash silently truncates a `-c` argument longer than 8186 characters: no error, no warning. When the cut lands mid-quote, bash reports a parse error on an innocent line. When it lands on a line boundary, the call returns exit 0 with empty output and executes nothing — indistinguishable from a genuine "no matches", "clean working tree", or "tests passed". The error names bash, never this plugin, so users never report it. That false green is the reason to ship this fix.

## Cause

`appendEnvVar()` used `fs.appendFileSync` on every SessionStart. SessionStart fires on start, resume and compaction — not once per session. The file grew without bound (measured: 57 copies of each variable, 15 KiB). Once past the shell limit, every Bash tool call is compromised.

## Fix

Rewrite the lines for the variable being written instead of appending. Only lines belonging to that variable are touched, so other hooks sharing the file keep their own. A file already bloated by an older build is repaired on the next SessionStart. Only `ENOENT` is treated as empty; any other read error aborts rather than replacing the whole file, because `handleSessionStart` runs three read-modify-write cycles back to back. Empty trailing elements from splitting on the block's own newline are filtered so the file cannot re-grow by one byte per call.

Emission shape is unchanged: a single `export NAME=<shell-escaped>` line.

## Test plan

- [x] New `tests/session-lifecycle.test.mjs`: nine repeated SessionStart events leave byte length unchanged; a pre-bloated file is repaired and foreign lines are kept; a non-ENOENT read aborts without destroying the target
- [x] All three fail against the previous append implementation and pass with this change, verified by reverting the fix and re-running
- [x] No new failures in the existing suite on Windows: 51 → 54 passing, 13 failing before and after

The 13 pre-existing failures are unrelated to this change; I have filed them separately.
