### PR TITLE
docs: note that sandbox enforcement is Linux and macOS only

### DIFF
--- a/plugins/grok-build/scripts/grok-bridge.mjs
+++ b/plugins/grok-build/scripts/grok-bridge.mjs
@@ -330,7 +330,14 @@ async function executeReviewRun(request) {
     agent: "explore",
     // Headless runs have no user to click Approve, so "plan" mode with no
     // approver can hang or fail on any tool call. `sandbox: "read-only"` is
-    // the actual safety boundary here, so auto-approving within it is safe.
+    // what makes auto-approving acceptable here.
+    //
+    // Platform caveat, because this is the line someone reads before deciding
+    // what is safe to depend on: enforcement exists on Linux (Landlock) and
+    // macOS (Seatbelt) only. The sandbox documentation names no Windows
+    // mechanism, and xai-grok-sandbox's apply() takes a no-op branch when not
+    // built for unix. buildHeadlessArgs passes no tool restrictions, so on
+    // Windows this call runs auto-approved with nothing constraining it.
     alwaysApprove: true,
     sandbox: "read-only",
     model: request.model,
@@ -449,8 +456,15 @@ async function executeTaskRun(request) {
     effort: request.effort,
     // Headless runs have no user to click Approve, so a read-only run using
     // "plan" mode with no approver can hang or fail on any tool call.
-    // `sandbox: "read-only"` is the actual safety boundary, so auto-approve
-    // is safe in both the write and read-only cases here.
+    // `sandbox: "read-only"` is what makes auto-approve acceptable in the
+    // read-only case; in the write case the user has asked for write access.
+    //
+    // Platform caveat, same as the review path above: sandbox enforcement
+    // exists on Linux (Landlock) and macOS (Seatbelt) only. The sandbox
+    // documentation names no Windows mechanism, and xai-grok-sandbox's apply()
+    // takes a no-op branch when not built for unix. buildHeadlessArgs passes no
+    // tool restrictions, so on Windows a read-only run is auto-approved with
+    // nothing constraining it.
     alwaysApprove: true,
     sandbox: write ? undefined : "read-only",
     outputFormat: "plain",


### PR DESCRIPTION
## Summary

Two comments in `grok-bridge.mjs` state that `sandbox: "read-only"` is the safety boundary that makes auto-approval acceptable, without qualification. On Windows it is not, and these are the lines someone reads before deciding what is safe to depend on.

This qualifies both with the platform limitation. **Comments only — no behaviour change.**

## Why

Your sandbox documentation lists enforcement for Linux (Landlock) and macOS (Seatbelt) and names no Windows mechanism. In `xai-org/grok-build`, `crates/codegen/xai-grok-sandbox/src/lib.rs`, `apply()` is gated:

```rust
#[cfg(all(feature = "enforce", unix))]
pub fn apply(&mut self, workspace: &Path) -> anyhow::Result<()> { /* kernel enforcement */ }

#[cfg(not(all(feature = "enforce", unix)))]
pub fn apply(&mut self, _workspace: &Path) -> anyhow::Result<()> {
    tracing::info!(/* ... */);
    Ok(())
}
```

And since `buildHeadlessArgs` (`lib/grok.mjs:155-201`) passes no tool restrictions — no `--disallowed-tools`, no `--deny`, no `--tools` — the sandbox is not the primary barrier for a read-only run but the only one. So on Windows a read-only run is auto-approved with nothing constraining it.

I measured it before writing this: calling `grok` with this plugin's argv shape on Windows, a read-only run wrote and read files outside its `--cwd`, with controls confirming the runs were otherwise working. Same on `1.0.0 (3cd0d0cbce)` and `0.2.118 (1e1687c1cf)`, so it is not a recent change.

## What this does and does not do

It makes the comments accurate. It does not change behaviour, add a warning, or alter what is passed to the CLI — those would be your call rather than a drive-by patch.

See the linked issue for the fuller picture, including a second option: enforcing at the tool layer with `--disallowed-tools` and `--deny` so the guarantee holds on every platform, since it asks nothing of the OS. That is a change to your safety model rather than a documentation fix, so I have not sent it unasked.

## Verification

- Every added and every removed line is a comment
- `node --check plugins/grok-build/scripts/grok-bridge.mjs` passes
- `npm test` gives 64 tests / 51 pass / 13 fail, identical to this branch's base at `92b76a6` (those 13 are a pre-existing Windows fixture issue, filed separately)
