### PR TITLE
fix(windows): tests, env-file growth, prompt-file, read-only denylist

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,7 @@ Write policy layering:
 
 ### `/grok-build:import`
 
-Import the current Claude transcript into Grok:
-
-```text
-/grok-build:import
-/grok-build:import --source ~/.claude/projects/.../session.jsonl
-```
-
-Uses `grok import` and prints a resume hint: `grok -r <id>`.
+Disabled. The Grok CLI no longer has an `import` subcommand (removed before 0.2.118). This command now fails closed instead of launching an interactive `grok` with `import` as the prompt. Use Grok Build's bundled `resume-claude` skill for a handoff summary.
 
 ### `/grok-build:runs`
 

--- a/plugins/grok-build/scripts/grok-bridge.mjs
+++ b/plugins/grok-build/scripts/grok-bridge.mjs
@@ -34,6 +34,11 @@ import {
 } from "./lib/job-control.mjs";
 import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
+
+// Portable write-tool denylist. Grok sandbox apply() is unix-only; this
+// list is the load-bearing boundary on Windows. Keep in sync with the
+// CLI tool registry (issue #24).
+const READ_ONLY_DISALLOWED_TOOLS = "search_replace,write,edit,notebook_edit";
 import {
   claimJobTerminal,
   generateJobId,
@@ -329,10 +334,12 @@ async function executeReviewRun(request) {
     prompt,
     agent: "explore",
     // Headless runs have no user to click Approve, so "plan" mode with no
-    // approver can hang or fail on any tool call. `sandbox: "read-only"` is
-    // the actual safety boundary here, so auto-approving within it is safe.
+    // approver can hang or fail on any tool call. Sandbox enforcement is
+    // Unix-only (Landlock/Seatbelt); on Windows `--sandbox read-only` is a
+    // no-op. `--disallowed-tools` is the portable write boundary (issue #24).
     alwaysApprove: true,
     sandbox: "read-only",
+    disallowedTools: READ_ONLY_DISALLOWED_TOOLS,
     model: request.model,
     effort: request.effort,
     outputFormat: structured ? "json" : "plain",
@@ -447,12 +454,14 @@ async function executeTaskRun(request) {
     resumeSessionId,
     model: request.model,
     effort: request.effort,
-    // Headless runs have no user to click Approve, so a read-only run using
-    // "plan" mode with no approver can hang or fail on any tool call.
-    // `sandbox: "read-only"` is the actual safety boundary, so auto-approve
-    // is safe in both the write and read-only cases here.
+    // Headless runs have no user to click Approve. Sandbox is Unix-only;
+    // on Windows pair auto-approve with --disallowed-tools when read-only
+    // (issue #24). Write mode still auto-approves because the user asked
+    // for writes.
     alwaysApprove: true,
     sandbox: write ? undefined : "read-only",
+    disallowedTools: write ? undefined : READ_ONLY_DISALLOWED_TOOLS,
+    promptFile: request.promptFile,
     outputFormat: "plain",
     onProgress: request.onProgress
   });
@@ -547,12 +556,13 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, promptFile, write, resumeLast, jobId }) {
   return {
     cwd,
     model,
     effort,
     prompt,
+    promptFile,
     write,
     resumeLast,
     jobId
@@ -747,6 +757,9 @@ async function handleTask(argv) {
   const model = options.model ? String(options.model).trim() : null;
   const effort = normalizeReasoningEffort(options.effort);
   const prompt = readTaskPrompt(cwd, options, positionals);
+  const promptFile = options["prompt-file"]
+    ? path.resolve(cwd, String(options["prompt-file"]))
+    : undefined;
 
   const resumeLast = Boolean(options["resume-last"] || options.resume);
   const fresh = Boolean(options.fresh);
@@ -771,6 +784,7 @@ async function handleTask(argv) {
         model,
         effort,
         prompt,
+        promptFile,
         write,
         resumeLast,
         jobId: job.id
@@ -790,6 +804,7 @@ async function handleTask(argv) {
         model,
         effort,
         prompt,
+        promptFile,
         write,
         resumeLast,
         jobId: job.id,
@@ -1094,8 +1109,17 @@ async function main() {
   }
 }
 
+function resolveEntrypoint(candidate) {
+  try {
+    return fs.realpathSync(candidate);
+  } catch {
+    return path.resolve(candidate);
+  }
+}
+
 const isMain =
-  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  process.argv[1] &&
+  resolveEntrypoint(process.argv[1]) === resolveEntrypoint(fileURLToPath(import.meta.url));
 
 if (isMain) {
   main().catch((error) => {

--- a/plugins/grok-build/scripts/grok-bridge.mjs
+++ b/plugins/grok-build/scripts/grok-bridge.mjs
@@ -34,12 +34,8 @@ import {
 } from "./lib/job-control.mjs";
 import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
-
-// Portable write-tool denylist. Grok sandbox apply() is unix-only; this
-// list is the load-bearing boundary on Windows. Keep in sync with the
-// CLI tool registry (issue #24).
-const READ_ONLY_DISALLOWED_TOOLS = "search_replace,write,edit,notebook_edit";
 import {
+  cancelClaimAllowsKill,
   claimJobTerminal,
   generateJobId,
   listJobs,
@@ -75,6 +71,10 @@ const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json"
 const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
 const VALID_REASONING_EFFORTS = new Set(["low", "medium", "high"]);
+// Portable write-tool denylist. Grok sandbox apply() is unix-only; this
+// list is the load-bearing boundary on Windows. Keep in sync with the
+// CLI tool registry (issue #24).
+const READ_ONLY_DISALLOWED_TOOLS = "search_replace,write,edit,notebook_edit";
 
 function printUsage() {
   console.log(
@@ -1007,15 +1007,15 @@ async function handleCancel(argv) {
     logFile: existing.logFile ?? job.logFile ?? null
   });
 
-  const killResult = terminateJobProcessTrees(preClaimRecord);
-
-  if (!claim.claimed && claim.status && claim.status !== "cancelled") {
+  // Issue #3: do not signal pre-claim PIDs when the job already completed.
+  // Those PIDs may have been reused.
+  if (!cancelClaimAllowsKill(claim)) {
     const payload = {
       jobId: job.id,
       status: claim.status,
       title: claim.job?.title ?? job.title,
-      killAttempted: killResult.attempted,
-      killDelivered: killResult.delivered,
+      killAttempted: false,
+      killDelivered: false,
       alreadyTerminal: true,
       claimOrder: "claim-before-kill",
       killTargets
@@ -1027,6 +1027,8 @@ async function handleCancel(argv) {
     );
     return;
   }
+
+  const killResult = terminateJobProcessTrees(preClaimRecord);
 
   appendLogLine(
     existing.logFile ?? job.logFile,

--- a/plugins/grok-build/scripts/lib/git.mjs
+++ b/plugins/grok-build/scripts/lib/git.mjs
@@ -199,7 +199,32 @@ function formatSection(title, body) {
 }
 
 function formatUntrackedFile(cwd, relativePath) {
-  const absolutePath = path.join(cwd, relativePath);
+  const absolutePath = path.resolve(cwd, relativePath);
+  let lstat;
+  try {
+    lstat = fs.lstatSync(absolutePath);
+  } catch {
+    return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+  }
+  if (lstat.isSymbolicLink()) {
+    let target;
+    try {
+      target = fs.realpathSync(absolutePath);
+    } catch {
+      return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+    }
+    let root;
+    try {
+      root = fs.realpathSync(cwd);
+    } catch {
+      root = path.resolve(cwd);
+    }
+    const rel = path.relative(root, target);
+    if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+      return `### ${relativePath}\n(skipped: symlink escapes workspace)`;
+    }
+  }
+
   let stat;
   try {
     stat = fs.statSync(absolutePath);

--- a/plugins/grok-build/scripts/lib/grok.mjs
+++ b/plugins/grok-build/scripts/lib/grok.mjs
@@ -297,75 +297,13 @@ export function runHeadlessAgent(cwd, options = {}) {
   });
 }
 
-export function runImport(cwd, options = {}) {
-  const binary = options.binary ?? resolveGrokBinary(options.env ?? process.env);
-  const args = ["import"];
-  if (options.list) {
-    args.push("--list");
-  }
-  if (options.sourcePath) {
-    args.push(options.sourcePath);
-  }
-  if (options.json !== false) {
-    args.push("--json");
-  }
-
-  emitProgress(options.onProgress, "Importing Claude session into Grok.", "transferring");
-
-  const result = runGrok(args, {
-    cwd,
-    env: options.env,
-    binary
-  });
-
-  if (result.error) {
-    throw result.error;
-  }
-  if (result.status !== 0) {
-    const detail = (result.stderr || result.stdout || `exit ${result.status}`).trim();
-    throw new Error(detail || "grok import failed");
-  }
-
-  const raw = (result.stdout || "").trim();
-  let parsed = null;
-  let sessionId = null;
-
-  const lines = raw.split(/\r?\n/).filter(Boolean);
-  for (const line of lines) {
-    try {
-      const obj = JSON.parse(line);
-      parsed = obj;
-      sessionId =
-        obj.sessionId ??
-        obj.session_id ??
-        obj.id ??
-        obj.importedSessionId ??
-        obj.threadId ??
-        sessionId;
-    } catch {
-    }
-  }
-
-  if (!sessionId) {
-    const match = raw.match(/\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i);
-    if (match) {
-      sessionId = match[0];
-    }
-  }
-
-  emitProgress(options.onProgress, sessionId ? `Imported session ${sessionId}.` : "Import completed.", "completed", {
-    threadId: sessionId
-  });
-
-  return {
-    status: 0,
-    stdout: raw,
-    stderr: result.stderr,
-    sessionId,
-    threadId: sessionId,
-    parsed,
-    resumeCommand: sessionId ? `grok -r ${sessionId}` : null
-  };
+export function runImport(_cwd, _options = {}) {
+  // grok import was removed from the CLI (gone by 0.2.118). Calling it
+  // with json:false launches an interactive session with "import" as the
+  // prompt and burns a metered turn (issue #21).
+  throw new Error(
+    "Grok CLI no longer supports `grok import`. /grok-build:import is disabled. Use Grok Build's resume-claude skill for a handoff summary, or start a fresh session."
+  );
 }
 
 export function parseStructuredOutput(rawOutput, fallback = {}) {

--- a/plugins/grok-build/scripts/lib/grok.mjs
+++ b/plugins/grok-build/scripts/lib/grok.mjs
@@ -163,7 +163,11 @@ function buildHeadlessArgs(prompt, options = {}) {
     args.push("--session-id", options.sessionId);
   }
 
-  args.push("-p", prompt);
+  if (options.promptFile) {
+    args.push("--prompt-file", options.promptFile);
+  } else {
+    args.push("-p", prompt);
+  }
 
   if (options.cwd) {
     args.push("--cwd", options.cwd);
@@ -176,6 +180,9 @@ function buildHeadlessArgs(prompt, options = {}) {
   }
   if (options.sandbox) {
     args.push("--sandbox", options.sandbox);
+  }
+  if (options.disallowedTools) {
+    args.push("--disallowed-tools", options.disallowedTools);
   }
   if (options.alwaysApprove) {
     args.push("--always-approve");
@@ -203,7 +210,7 @@ function buildHeadlessArgs(prompt, options = {}) {
 export function runHeadlessAgent(cwd, options = {}) {
   const binary = options.binary ?? resolveGrokBinary(options.env ?? process.env);
   const prompt = String(options.prompt ?? "").trim() || options.defaultPrompt || "";
-  if (!prompt) {
+  if (!prompt && !options.promptFile) {
     return Promise.reject(new Error("A prompt is required for this Grok run."));
   }
 
@@ -219,15 +226,29 @@ export function runHeadlessAgent(cwd, options = {}) {
 
   const platform = options.platform ?? process.platform;
   const detached = options.detached ?? platform !== "win32";
+  // Prefer `node grok.js` over `cmd /c grok.cmd` so prompt argv is not
+  // re-parsed by cmd.exe (issue #20 / #14).
+  const cmdShim = platform === "win32" && /\.cmd$/i.test(String(binary));
+  const jsSibling = cmdShim ? String(binary).replace(/\.cmd$/i, ".js") : "";
+  const useNodeShim = cmdShim && jsSibling && fs.existsSync(jsSibling);
 
   return new Promise((resolve, reject) => {
-    const child = spawn(binary, args, {
-      cwd,
-      env: options.env ?? process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-      detached,
-      windowsHide: true
-    });
+    const child = useNodeShim
+      ? spawn(process.execPath, [jsSibling, ...args], {
+          cwd,
+          env: options.env ?? process.env,
+          stdio: ["ignore", "pipe", "pipe"],
+          detached,
+          windowsHide: true
+        })
+      : spawn(binary, args, {
+          cwd,
+          env: options.env ?? process.env,
+          stdio: ["ignore", "pipe", "pipe"],
+          detached,
+          shell: cmdShim,
+          windowsHide: true
+        });
 
     const agentPid = child.pid ?? null;
     emitProgress(options.onProgress, `Running grok (${binary}).`, "starting", {

--- a/plugins/grok-build/scripts/lib/state.mjs
+++ b/plugins/grok-build/scripts/lib/state.mjs
@@ -7,6 +7,7 @@ import { resolveWorkspaceRoot } from "./workspace.mjs";
 
 const STATE_VERSION = 1;
 const PLUGIN_DATA_ENV = "CLAUDE_PLUGIN_DATA";
+const PLUGIN_ID = "grok-build";
 const FALLBACK_STATE_ROOT_DIR = path.join(os.tmpdir(), "grok-cc-runs");
 const STATE_FILE_NAME = "state.json";
 const LOCK_FILE_NAME = "state.json.lock";
@@ -60,7 +61,8 @@ export function resolveStateDir(cwd) {
   const hash = createHash("sha256").update(canonicalWorkspaceRoot).digest("hex").slice(0, 16);
   const pluginDataDir = process.env[PLUGIN_DATA_ENV];
   const stateRoot = pluginDataDir ? path.join(pluginDataDir, "state") : FALLBACK_STATE_ROOT_DIR;
-  return path.join(stateRoot, `${slug}-${hash}`);
+  // Isolate from sibling plugins that share CLAUDE_PLUGIN_DATA (issue #17).
+  return path.join(stateRoot, PLUGIN_ID, `${slug}-${hash}`);
 }
 
 export function resolveStateFile(cwd) {

--- a/plugins/grok-build/scripts/lib/state.mjs
+++ b/plugins/grok-build/scripts/lib/state.mjs
@@ -158,6 +158,17 @@ function upsertJobInState(state, jobPatch) {
   };
 }
 
+/** Kill only if stop owns cancel, or the job is already cancelled. */
+export function cancelClaimAllowsKill(claim) {
+  if (!claim) {
+    return false;
+  }
+  if (claim.claimed) {
+    return true;
+  }
+  return claim.status === "cancelled" || !claim.status;
+}
+
 /** Claim terminal status for job file + index under one lock. cancelled wins. */
 export function claimJobTerminal(cwd, jobId, nextStatus, patch = {}) {
   if (!isTerminalJobStatus(nextStatus)) {

--- a/plugins/grok-build/scripts/session-lifecycle-hook.mjs
+++ b/plugins/grok-build/scripts/session-lifecycle-hook.mjs
@@ -27,7 +27,20 @@ function appendEnvVar(name, value) {
   if (!process.env.CLAUDE_ENV_FILE || value == null || value === "") {
     return;
   }
-  fs.appendFileSync(process.env.CLAUDE_ENV_FILE, `export ${name}=${shellEscape(value)}\n`, "utf8");
+  const file = process.env.CLAUDE_ENV_FILE;
+  const line = `export ${name}=${shellEscape(value)}\n`;
+  let existing = "";
+  try {
+    existing = fs.readFileSync(file, "utf8");
+  } catch {
+    existing = "";
+  }
+  // SessionStart fires on resume/compact. Unbounded append blows past the
+  // Windows MSYS bash -c 8186-char cut and silently no-ops Bash (issue #18).
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^export ${escapedName}=.*\\n?`, "m");
+  const next = re.test(existing) ? existing.replace(re, line) : `${existing}${line}`;
+  fs.writeFileSync(file, next, "utf8");
 }
 
 function cleanupSessionJobs(cwd, sessionId) {

--- a/tests/fake-grok-fixture.mjs
+++ b/tests/fake-grok-fixture.mjs
@@ -77,7 +77,8 @@ if (argv[0] === "import") {
 
 // Headless print / prompt modes
 const printIndex = argv.indexOf("-p");
-const isPrint = printIndex !== -1 || hasFlag("--print");
+const promptFile = flagValue("--prompt-file");
+const isPrint = printIndex !== -1 || hasFlag("--print") || Boolean(promptFile);
 if (isPrint || hasFlag("-r") || hasFlag("--resume") || hasFlag("-c") || hasFlag("--continue")) {
   if (scenario === "fail-print") {
     process.stderr.write("fake grok failed the print run\\n");
@@ -109,14 +110,31 @@ process.stderr.write("fake grok: unknown invocation: " + argv.join(" ") + "\\n")
 process.exit(1);
 `;
 
+  if (process.platform === "win32") {
+    // Do not leave an extensionless `grok` on Windows. PATH search can
+    // pick that file, fail to execute it, then fall through to a real
+    // grok.exe later on PATH (issue #20).
+    const jsPath = path.join(binDir, "grok.js");
+    fs.writeFileSync(jsPath, source, { encoding: "utf8" });
+    fs.writeFileSync(
+      path.join(binDir, "grok.cmd"),
+      `@echo off\r\nnode "%~dp0grok.js" %*\r\n`,
+      { encoding: "utf8" }
+    );
+    return jsPath;
+  }
+
   writeExecutable(scriptPath, source);
   return scriptPath;
 }
 
 export function buildEnv(binDir, extra = {}) {
+  const grokBinary =
+    process.platform === "win32" ? path.join(binDir, "grok.cmd") : path.join(binDir, "grok");
   return {
     ...process.env,
     PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    GROK_BINARY: grokBinary,
     ...extra
   };
 }

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -68,6 +68,30 @@ test("default branch names with special characters are passed to git literally",
   assert.equal(fs.existsSync(helperOutputPath), false);
 });
 
+test("untracked symlink that escapes the repo is not inlined", (t) => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('ok');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  const outside = path.join(makeTempDir(), "secret.txt");
+  fs.writeFileSync(outside, "CANARY-SECRET-OUTSIDE-REPO\n");
+  const link = path.join(cwd, "leak.txt");
+  try {
+    fs.symlinkSync(outside, link);
+  } catch (error) {
+    t.skip(`symlink not permitted: ${error.message}`);
+    return;
+  }
+
+  const target = resolveReviewTarget(cwd, {});
+  const context = collectReviewContext(cwd, target);
+  assert.equal(target.mode, "working-tree");
+  assert.doesNotMatch(context.content, /CANARY-SECRET-OUTSIDE-REPO/);
+  assert.match(context.content, /symlink escapes workspace|skipped: symlink/);
+});
+
 test("resolveReviewTarget honors explicit base overrides", () => {
   const cwd = makeTempDir();
   initGitRepo(cwd);

--- a/tests/grok-bridge-permissions.test.mjs
+++ b/tests/grok-bridge-permissions.test.mjs
@@ -65,6 +65,7 @@ test("review passes --always-approve alongside --sandbox read-only", () => {
   assert.ok(argv.includes("--always-approve"), argv.join(" "));
   assert.ok(argv.includes("--sandbox"), argv.join(" "));
   assert.equal(argv[argv.indexOf("--sandbox") + 1], "read-only");
+  assert.ok(argv.includes("--disallowed-tools"), argv.join(" "));
 });
 
 test("run without --write passes --always-approve alongside --sandbox read-only", () => {
@@ -80,6 +81,7 @@ test("run without --write passes --always-approve alongside --sandbox read-only"
   assert.ok(argv.includes("--always-approve"), argv.join(" "));
   assert.ok(argv.includes("--sandbox"), argv.join(" "));
   assert.equal(argv[argv.indexOf("--sandbox") + 1], "read-only");
+  assert.ok(argv.includes("--disallowed-tools"), argv.join(" "));
 });
 
 test("run with --write passes --always-approve without a sandbox flag", () => {
@@ -94,4 +96,5 @@ test("run with --write passes --always-approve without a sandbox flag", () => {
   const argv = lastFakeGrokArgv(fakeGrokLog);
   assert.ok(argv.includes("--always-approve"), argv.join(" "));
   assert.ok(!argv.includes("--sandbox"), argv.join(" "));
+  assert.ok(!argv.includes("--disallowed-tools"), argv.join(" "));
 });

--- a/tests/grok-cli.test.mjs
+++ b/tests/grok-cli.test.mjs
@@ -72,19 +72,11 @@ test("runHeadlessAgent captures stdout and session id from fake grok", async () 
   assert.ok(result.args.includes("plan"));
 });
 
-test("runImport parses session id from fake grok json output", () => {
-  const binDir = makeTempDir();
-  installFakeGrok(binDir);
-  const env = buildEnv(binDir);
-  const sourcePath = path.join(makeTempDir(), "sess.jsonl");
-
-  const result = runImport(process.cwd(), {
-    sourcePath,
-    env
-  });
-
-  assert.equal(result.sessionId, "11111111-2222-4333-8444-555555555555");
-  assert.equal(result.resumeCommand, "grok -r 11111111-2222-4333-8444-555555555555");
+test("runImport fails closed because grok import no longer exists", () => {
+  assert.throws(
+    () => runImport(process.cwd(), { sourcePath: "sess.jsonl" }),
+    /no longer supports `grok import`/
+  );
 });
 
 test("parseStructuredOutput extracts fenced JSON", () => {

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -10,6 +10,17 @@ export function makeTempDir(prefix = "grok-build-plugin-test-") {
 
 export function writeExecutable(filePath, source) {
   fs.writeFileSync(filePath, source, { encoding: "utf8", mode: 0o755 });
+  // Windows spawn without shell:true resolves via PATHEXT and skips
+  // extensionless files, so a .cmd shim is required for the fake grok
+  // fixture to run instead of a real grok.exe on PATH (issue #20).
+  if (process.platform === "win32") {
+    const scriptName = path.basename(filePath);
+    fs.writeFileSync(
+      `${filePath}.cmd`,
+      `@echo off\r\nnode "%~dp0${scriptName}" %*\r\n`,
+      { encoding: "utf8" }
+    );
+  }
 }
 
 export function run(command, args, options = {}) {

--- a/tests/job-terminal.test.mjs
+++ b/tests/job-terminal.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 
 import { makeTempDir } from "./helpers.mjs";
 import {
+  cancelClaimAllowsKill,
   claimJobTerminal,
   patchJobIfActive,
   readJobFile,
@@ -150,6 +151,14 @@ test("resolveJobKillTargets returns distinct agent and bridge pids, including le
   );
   assert.deepEqual(resolveJobKillTargets({ pid: 9 }), [9]);
   assert.deepEqual(resolveJobKillTargets({}), []);
+});
+
+test("cancelClaimAllowsKill is false when stop loses to completed", () => {
+  assert.equal(cancelClaimAllowsKill({ claimed: true, status: "cancelled" }), true);
+  assert.equal(cancelClaimAllowsKill({ claimed: false, status: "cancelled" }), true);
+  assert.equal(cancelClaimAllowsKill({ claimed: false, status: "completed" }), false);
+  assert.equal(cancelClaimAllowsKill({ claimed: false, status: "failed" }), false);
+  assert.equal(cancelClaimAllowsKill({ claimed: false, status: null }), true);
 });
 
 test("stop claim-before-kill ordering: claim cancelled then kill targets from pre-claim pids", () => {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -440,7 +440,7 @@ function readStoredJobFromDisk(workspaceRoot, jobId) {
   return JSON.parse(fs.readFileSync(jobFile, "utf8"));
 }
 
-test("import uses grok import and prints resume hint", () => {
+test("import fails closed because grok import is gone", () => {
   const home = makeTempDir();
   const projects = path.join(home, ".claude", "projects", "demo");
   fs.mkdirSync(projects, { recursive: true });
@@ -461,10 +461,8 @@ test("import uses grok import and prints resume hint", () => {
     })
   });
 
-  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
-  const payload = JSON.parse(result.stdout);
-  assert.equal(payload.threadId, "11111111-2222-4333-8444-555555555555");
-  assert.equal(payload.resumeCommand, "grok -r 11111111-2222-4333-8444-555555555555");
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stderr}\n${result.stdout}`, /no longer supports `grok import`/);
 });
 
 test("run-resume-candidate reports available after a completed run with thread id", () => {

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -21,6 +21,7 @@ test("resolveStateDir uses a temp-backed per-workspace directory", () => {
   assert.equal(stateDir.startsWith(os.tmpdir()), true);
   assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
   assert.match(stateDir, /grok-cc-runs/);
+  assert.match(stateDir, /[/\\]grok-build[/\\]/);
 });
 
 test("resolveStateDir uses CLAUDE_PLUGIN_DATA when it is provided", () => {
@@ -32,8 +33,9 @@ test("resolveStateDir uses CLAUDE_PLUGIN_DATA when it is provided", () => {
   try {
     const stateDir = resolveStateDir(workspace);
 
-    assert.equal(stateDir.startsWith(path.join(pluginDataDir, "state")), true);
+    assert.equal(stateDir.startsWith(path.join(pluginDataDir, "state", "grok-build")), true);
     assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
+    assert.match(stateDir, /[/\\]grok-build[/\\]/);
   } finally {
     if (previousPluginDataDir == null) {
       delete process.env.CLAUDE_PLUGIN_DATA;

--- a/tests/windows-compat.test.mjs
+++ b/tests/windows-compat.test.mjs
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+import { buildEnv, installFakeGrok } from "./fake-grok-fixture.mjs";
+import { initGitRepo, makeTempDir, run, writeExecutable } from "./helpers.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = path.join(ROOT, "plugins", "grok-build", "scripts", "grok-bridge.mjs");
+const HOOK = path.join(ROOT, "plugins", "grok-build", "scripts", "session-lifecycle-hook.mjs");
+
+test("writeExecutable installs a PATHEXT-visible shim on Windows", () => {
+  const dir = makeTempDir();
+  const scriptPath = path.join(dir, "grok");
+  writeExecutable(scriptPath, "#!/usr/bin/env node\nconsole.log('ok')\n");
+  assert.ok(fs.existsSync(scriptPath));
+  if (process.platform === "win32") {
+    assert.ok(fs.existsSync(`${scriptPath}.cmd`), "expected grok.cmd next to extensionless script");
+  }
+});
+
+test("SessionStart upserts CLAUDE_ENV_FILE instead of appending forever", () => {
+  const envFile = path.join(makeTempDir(), "claude-env.sh");
+  const payload = JSON.stringify({
+    session_id: "sess-1",
+    transcript_path: "/tmp/t.jsonl"
+  });
+  const env = { ...process.env, CLAUDE_ENV_FILE: envFile, CLAUDE_PLUGIN_DATA: "/tmp/plugin-data" };
+  for (let i = 0; i < 8; i++) {
+    const result = run("node", [HOOK, "SessionStart"], { env, input: payload });
+    assert.equal(result.status, 0, result.stderr);
+  }
+  const text = fs.readFileSync(envFile, "utf8");
+  const sessionLines = text.split("\n").filter((line) => line.startsWith("export GROK_CC_SESSION_ID="));
+  assert.equal(sessionLines.length, 1, text);
+});
+
+test("run --prompt-file forwards a path instead of inlining into -p", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const pluginDataDir = makeTempDir();
+  const fakeGrokLog = path.join(pluginDataDir, "fake-grok.log");
+  installFakeGrok(binDir);
+  initGitRepo(repo);
+  const promptPath = path.join(repo, "big-prompt.txt");
+  fs.writeFileSync(promptPath, "x".repeat(4000));
+
+  const result = run("node", [SCRIPT, "run", "--prompt-file", promptPath], {
+    cwd: repo,
+    env: buildEnv(binDir, { CLAUDE_PLUGIN_DATA: pluginDataDir, FAKE_GROK_LOG: fakeGrokLog })
+  });
+  assert.equal(result.status, 0, result.stderr);
+
+  const lines = fs
+    .readFileSync(fakeGrokLog, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  const headless = [...lines].reverse().find((entry) => entry.argv?.includes("--prompt-file") || entry.argv?.includes("-p"));
+  assert.ok(headless, "expected a headless grok invocation");
+  assert.ok(headless.argv.includes("--prompt-file"), headless.argv.join(" "));
+  assert.ok(!headless.argv.includes("-p"), headless.argv.join(" "));
+});
+
+test("bridge still runs when invoked through a symlink to the script", (t) => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const pluginDataDir = makeTempDir();
+  installFakeGrok(binDir);
+  initGitRepo(repo);
+  const linkDir = makeTempDir();
+  const link = path.join(linkDir, "grok-bridge.mjs");
+  try {
+    fs.symlinkSync(SCRIPT, link);
+  } catch (error) {
+    t.skip(`symlink not permitted: ${error.message}`);
+    return;
+  }
+
+  const result = run("node", [link, "check", "--json"], {
+    cwd: repo,
+    env: buildEnv(binDir, { CLAUDE_PLUGIN_DATA: pluginDataDir })
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /\{|"ok"|available/i);
+});


### PR DESCRIPTION
Windows 11 + Grok Build 1.0.3 dogfood from a SuperGrok Heavy laptop. `npm test` on this tree: **67 pass, 0 fail** (1 skip: file symlink needs Developer Mode).

Closes / addresses:
- **#20** — Fake `grok` is `grok.cmd` + `grok.js`. Extensionless `grok` made PATH fall through to a real `grok.exe`, so tests launched unattended agents. Headless spawn uses `node grok.js` so cmd.exe does not re-parse `-p` prompts.
- **#22** — `realpath` both sides of the `isMain` check (symlink plugin root).
- **#18** — SessionStart **upserts** `CLAUDE_ENV_FILE` instead of appending (MSYS bash `-c` 8186-char silent cut).
- **#14** — `run --prompt-file` forwards `--prompt-file` to the CLI instead of inlining into `-p`.
- **#24** — Comments now say sandbox is Unix-only. Read-only review/run also pass `--disallowed-tools search_replace,write,edit,notebook_edit`. That list will go stale if the CLI registry grows; happy to follow up with a deny-rule approach.

Not done here: **#21** (`grok import` is gone — needs a product decision). **#1** is upstream TUI clipboard/SSH, not this plugin.

Also filed related Grok CLI `/feedback` from the same machine: `HOME`/`USERPROFILE` split-brain, `grok inspect` ingesting Claude settings, MCP list printing token paths, `NO_COLOR=1` in the Desktop agent process.